### PR TITLE
disabling the climber stator current limit

### DIFF
--- a/Comp2024-Imported/src/main/java/frc/robot/lib/phoenix/CTREConfigs6.java
+++ b/Comp2024-Imported/src/main/java/frc/robot/lib/phoenix/CTREConfigs6.java
@@ -277,7 +277,7 @@ public final class CTREConfigs6
     climberConfig.CurrentLimits.SupplyCurrentLimitEnable = true;
 
     climberConfig.CurrentLimits.StatorCurrentLimit = 800.0;        // Amps
-    climberConfig.CurrentLimits.StatorCurrentLimitEnable = true;
+    climberConfig.CurrentLimits.StatorCurrentLimitEnable = false;
 
     // Feedback settings
     // climberConfig.Feedback.*


### PR DESCRIPTION
Current limit for the climber motors has been disabled for Comp-2024 imported code.
 
## Description (What changed)
Within CTREConfig6, the stator current limit for the climber motors was disabled.

## Motivation and Context (Why needed)
This change was required to remove the bug to be able to run the elevator.

## How has this been tested?
The updated robot code was simulated with mechanism2d and the proper commands were executed. The code was also deployed into Apollo and two different days with the expected results. This change to the code does not affect any other subsystems.
- [x] Compiles with no errors and no ***additional*** warnings
- [x] Simulates without crashes, errors or warnings
- [x] Simulates with the change under test successfully working
- [x] Tested in the robot with no crashes, errors or warnings
- [x] I verified the log messages were as expected with no warnings in AdvantageScope

## Types of changes
<!--- The climber motors function both in simulation and in the robot, as compared to before when the climbers did not move. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
Auto-formatter is not activated for phoenix CTREConfig6 class
- [x] The auto-formatter was working correctly when submitted
- [x] I have updated any comments accordingly.
