### PR TITLE
Instantiate Power and LED subsystems

### DIFF
--- a/Comp2025/src/main/java/frc/robot/Constants.java
+++ b/Comp2025/src/main/java/frc/robot/Constants.java
@@ -36,7 +36,7 @@ public class Constants
 
   // Phoenix firmware versions expected
   public static final int     kPhoenix5MajorVersion = ((22 * 256) + 0); // TODO: update CTRE version numbers for 2025
-  public static final int     kPhoenix6MajorVersion = 24;
+  public static final int     kPhoenix6MajorVersion = 25;
 
   /****************************************************************************
    * CAN IDs and PWM IDs

--- a/Comp2025/src/main/java/frc/robot/RobotContainer.java
+++ b/Comp2025/src/main/java/frc/robot/RobotContainer.java
@@ -45,7 +45,9 @@ import frc.robot.generated.TunerConstants;
 import frc.robot.subsystems.CommandSwerveDrivetrain;
 import frc.robot.subsystems.Elevator;
 import frc.robot.subsystems.LED;
+import frc.robot.subsystems.Power;
 import frc.robot.subsystems.Telemetry;
+import frc.robot.subsystems.Vision;
 
 /****************************************************************************
  * 
@@ -64,6 +66,9 @@ public class RobotContainer
 
   private static final LinearVelocity                 kMaxSpeed       = TunerConstants.kSpeedAt12Volts;     // Maximum top speed
   private static final AngularVelocity                kMaxAngularRate = RadiansPerSecond.of(3.0 * Math.PI); // Max 1.5 rot per second
+  private static final double                         kHeadingKp      = 10.0;
+  private static final double                         kHeadingKi      = 0.0;
+  private static final double                         kHeadingKd      = 0.0;
 
   // Setting up bindings for necessary control of the swerve drive platform
   private final SwerveRequest.FieldCentric            drive           = new SwerveRequest.FieldCentric( ) //
@@ -86,10 +91,10 @@ public class RobotContainer
   private final Telemetry                             logger          = new Telemetry(kMaxSpeed.in(MetersPerSecond));
 
   // The robot's shared subsystems
-  // private final HID                                   m_hid           = new HID(m_driverPad.getHID( ), m_operatorPad.getHID( ));
+  // private final HID                                   m_hid           = new HID(m_driverPad.getHID( ), m_operatorPad.getHID( )); // TODO: port HID code
   private final LED                                   m_led           = new LED( );
-  // private final Power                                 m_power         = new Power( );
-  // private final Vision                                m_vision        = new Vision( );
+  private final Power                                 m_power         = new Power( );
+  private final Vision                                m_vision        = new Vision( );
 
   // These subsystems may use LED or vision and must be created afterward
   private final CommandSwerveDrivetrain               m_drivetrain    = TunerConstants.createDrivetrain( );
@@ -104,8 +109,8 @@ public class RobotContainer
   {
     AUTOSTOP,         // AutoStop - sit still, do nothing
     AUTOLEAVE,        // Leave starting zone avoiding spikes
-    AUTOPRELOADSCORE, // Score preload at waypoints P1-P3 and score another from nearest spike
-    AUTOSCORE4,       // Score preload at waypoints P1-P3 and all spike notes at S1-S3
+    AUTOPRELOADSCORE, // Score preload at a branch
+    AUTOSCORE4,       // Score preload at a branch and score 3 more
     AUTOTEST          // Run a selected test auto
   }
 
@@ -162,7 +167,7 @@ public class RobotContainer
   {
     Robot.timeMarker("robotContainer: before DAQ thread");
     // Swerve steer PID for facing swerve request
-    facing.HeadingController = new PhoenixPIDController(10.0, 0.0, 0.0);  // Swerve steer PID for facing swerve request
+    facing.HeadingController = new PhoenixPIDController(kHeadingKp, kHeadingKi, kHeadingKd);  // Swerve steer PID for facing swerve request
     // Add dashboard widgets for commands
     addDashboardWidgets( );           // Add dashboard widgets for commands
     // Configure game controller buttons
@@ -208,7 +213,6 @@ public class RobotContainer
     //     m_hid.getHIDRumbleOperatorCommand(Constants.kRumbleOn, duration, Constants.kRumbleIntensity));
 
     // Network tables publisher objects
-
     SmartDashboard.putData("elevator", m_elevator);
 
     SmartDashboard.putData(CommandScheduler.getInstance( ));
@@ -226,22 +230,10 @@ public class RobotContainer
     //
     // Driver - A, B, X, Y
     //
-    //  --- Normal button definitions ---
-    //
-
     m_driverPad.a( ).onTrue(new LogCommand("driverPad", "A"));
     m_driverPad.b( ).onTrue(new LogCommand("driverPad", "B"));
     m_driverPad.x( ).onTrue(new LogCommand("driverPad", "X"));
     m_driverPad.y( ).onTrue(new LogCommand("driverPad", "Y"));
-    //
-    //  --- SysId button definitions ---
-    //
-    // Run SysId routines when holding A, B and X/Y.
-    // Note that each routine should be run exactly once in a single log.
-    // m_driverPad.a( ).and(m_driverPad.y( )).whileTrue(m_drivetrain.sysIdDynamic(Direction.kForward));
-    // m_driverPad.a( ).and(m_driverPad.x( )).whileTrue(m_drivetrain.sysIdDynamic(Direction.kReverse));
-    // m_driverPad.b( ).and(m_driverPad.y( )).whileTrue(m_drivetrain.sysIdQuasistatic(Direction.kForward));
-    // m_driverPad.b( ).and(m_driverPad.x( )).whileTrue(m_drivetrain.sysIdQuasistatic(Direction.kReverse));
 
     //
     // Driver - Bumpers, start, back
@@ -301,12 +293,11 @@ public class RobotContainer
     m_operatorPad.leftBumper( ).onTrue(new LogCommand("operPad", "left bumper"));
     m_operatorPad.rightBumper( ).onTrue(new LogCommand("operPad", "right bumper"));
     m_operatorPad.back( ).toggleOnTrue(m_elevator.getJoystickCommand(( ) -> getElevatorAxis( )));                  // aka View button
-    // m_operatorPad.start( ).onTrue(new InstantCommand(m_vision::rotateCameraStreamMode).ignoringDisable(true));  // aka Menu button
+    m_operatorPad.start( ).onTrue(new InstantCommand(m_vision::rotateCameraStreamMode).ignoringDisable(true));  // aka Menu button
 
     //
     // Operator - POV buttons
     //
-
     m_operatorPad.pov(0).onTrue(m_elevator.getMoveToPositionCommand(m_elevator::getHeightCoralL4));
     m_operatorPad.pov(90).onTrue(m_elevator.getMoveToPositionCommand(m_elevator::getHeightCoralL1));
     m_operatorPad.pov(180).onTrue(m_elevator.getMoveToPositionCommand(m_elevator::getHeightStowed));
@@ -494,9 +485,9 @@ public class RobotContainer
    */
   public void initialize( )
   {
-    // m_led.initialize( );
-    // m_power.initialize( );
-    // m_vision.initialize( );
+    m_led.initialize( );
+    m_power.initialize( );
+    m_vision.initialize( );
 
     m_elevator.initialize( );
   }
@@ -507,8 +498,8 @@ public class RobotContainer
    */
   public void printFaults( )
   {
-    // m_led.printFaults( );
-    // m_power.printFaults( );
+    m_led.printFaults( );
+    m_power.printFaults( );
 
     m_elevator.printFaults( );
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Enable Power and LED subsystems which were still disabled in robotContainer

## Description (What changed)
<!--- Describe your changes in detail -->
Uncommented the robotContainer lines which instantiated the Power and LED subystems. This was done previously, but somehow reverted. Also removed any SysID button assignments for swerve characterization.

## Motivation and Context (Why needed)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These subsystems were previously created and tested, but somehow disabled.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Compiles with no errors and no ***additional*** warnings
- [x] Simulates without crashes, errors or warnings
- [x] Simulates with the change under test successfully working
- [ ] Tested in the robot with no crashes, errors or warnings
- [x] I verified the log messages were as expected with no warnings in AdvantageScope

## Screenshots (optional: if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The auto-formatter was working correctly when submitted
- [x] I have updated any comments accordingly.
