### PR TITLE
Add hid subsystem

### DIFF
--- a/Comp2025/src/main/java/frc/robot/RobotContainer.java
+++ b/Comp2025/src/main/java/frc/robot/RobotContainer.java
@@ -230,7 +230,8 @@ public class RobotContainer
     //
     //  --- Normal button definitions ---
     //
-    m_driverPad.a( ).onTrue(new LogCommand("driverPad", "B"));
+
+    m_driverPad.a( ).onTrue(new LogCommand("driverPad", "A"));
     m_driverPad.b( ).onTrue(new LogCommand("driverPad", "B"));
     m_driverPad.x( ).onTrue(new LogCommand("driverPad", "X"));
     m_driverPad.y( ).onTrue(new LogCommand("driverPad", "Y"));

--- a/Comp2025/src/main/java/frc/robot/RobotContainer.java
+++ b/Comp2025/src/main/java/frc/robot/RobotContainer.java
@@ -6,6 +6,7 @@ package frc.robot;
 
 import static edu.wpi.first.units.Units.MetersPerSecond;
 import static edu.wpi.first.units.Units.RadiansPerSecond;
+import static edu.wpi.first.units.Units.Seconds;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -25,7 +26,7 @@ import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.LinearVelocity;
-// import edu.wpi.first.units.measure.Time;
+import edu.wpi.first.units.measure.Time;
 import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
@@ -44,6 +45,7 @@ import frc.robot.commands.LogCommand;
 import frc.robot.generated.TunerConstants;
 import frc.robot.subsystems.CommandSwerveDrivetrain;
 import frc.robot.subsystems.Elevator;
+import frc.robot.subsystems.HID;
 import frc.robot.subsystems.LED;
 import frc.robot.subsystems.Telemetry;
 
@@ -86,7 +88,7 @@ public class RobotContainer
   private final Telemetry                             logger          = new Telemetry(kMaxSpeed.in(MetersPerSecond));
 
   // The robot's shared subsystems
-  // private final HID                                   m_hid           = new HID(m_driverPad.getHID( ), m_operatorPad.getHID( ));
+  private final HID                                   m_hid           = new HID(m_driverPad.getHID( ), m_operatorPad.getHID( ));
   private final LED                                   m_led           = new LED( );
   // private final Power                                 m_power         = new Power( );
   // private final Vision                                m_vision        = new Vision( );
@@ -201,11 +203,11 @@ public class RobotContainer
     // Command tab
     // SmartDashboard.putData("PrepareToClimb", new PrepareToClimb(m_climber, m_feeder));
 
-    // Time duration = Seconds.of(1.0);
-    // SmartDashboard.putData("HIDRumbleDriver",
-    //     m_hid.getHIDRumbleDriverCommand(Constants.kRumbleOn, duration, Constants.kRumbleIntensity));
-    // SmartDashboard.putData("HIDRumbleOperator",
-    //     m_hid.getHIDRumbleOperatorCommand(Constants.kRumbleOn, duration, Constants.kRumbleIntensity));
+    Time duration = Seconds.of(1.0);
+    SmartDashboard.putData("HIDRumbleDriver",
+        m_hid.getHIDRumbleDriverCommand(Constants.kRumbleOn, duration, Constants.kRumbleIntensity));
+    SmartDashboard.putData("HIDRumbleOperator",
+        m_hid.getHIDRumbleOperatorCommand(Constants.kRumbleOn, duration, Constants.kRumbleIntensity));
 
     // Network tables publisher objects
 

--- a/Comp2025/src/main/java/frc/robot/RobotContainer.java
+++ b/Comp2025/src/main/java/frc/robot/RobotContainer.java
@@ -230,8 +230,7 @@ public class RobotContainer
     //
     //  --- Normal button definitions ---
     //
-
-    m_driverPad.a( ).onTrue(new LogCommand("driverPad", "A"));
+    m_driverPad.a( ).onTrue(new LogCommand("driverPad", "B"));
     m_driverPad.b( ).onTrue(new LogCommand("driverPad", "B"));
     m_driverPad.x( ).onTrue(new LogCommand("driverPad", "X"));
     m_driverPad.y( ).onTrue(new LogCommand("driverPad", "Y"));

--- a/Comp2025/src/main/java/frc/robot/subsystems/HID.java
+++ b/Comp2025/src/main/java/frc/robot/subsystems/HID.java
@@ -1,0 +1,212 @@
+//
+// HID subystem - HID feedback on robot
+//
+package frc.robot.subsystems;
+
+import static edu.wpi.first.units.Units.Seconds;
+
+import edu.wpi.first.units.measure.Time;
+import edu.wpi.first.wpilibj.DataLogManager;
+import edu.wpi.first.wpilibj.GenericHID;
+import edu.wpi.first.wpilibj.GenericHID.RumbleType;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+
+/****************************************************************************
+ * 
+ * HID subsystem class to provide rumble command factory
+ */
+public class HID extends SubsystemBase
+{
+  // Constants
+
+  // Member objects
+  private GenericHID m_driver;
+  private GenericHID m_operator;
+  private Timer      m_timerDriver   = new Timer( );
+  private Timer      m_timerOperator = new Timer( );
+  private Time       m_driverDuration;
+  private Time       m_operatorDuration;
+
+  /****************************************************************************
+   * 
+   * Constructor
+   * 
+   * @param driver
+   *          driver gamepad to initialize
+   * @param operator
+   *          operator gamepad to initialize
+   */
+  public HID(GenericHID driver, GenericHID operator)
+  {
+    setName("HID");
+    setSubsystem("HID");
+
+    m_driver = driver;
+    m_operator = operator;
+
+    initDashboard( );
+    initialize( );
+  }
+
+  /****************************************************************************
+   * 
+   * Periodic actions that run every scheduler loop time (20 msec)
+   */
+  @Override
+  public void periodic( )
+  {
+    // This method will be called once per scheduler run
+
+    if (m_timerDriver.isRunning( ) && m_timerDriver.hasElapsed(m_driverDuration.in(Seconds)))
+    {
+      m_timerDriver.stop( );
+      setHIDRumbleDriver(false, Seconds.of(0), 0);
+    }
+
+    if (m_timerOperator.isRunning( ) && m_timerOperator.hasElapsed(m_operatorDuration.in(Seconds)))
+    {
+      m_timerOperator.stop( );
+      setHIDRumbleOperator(false, Seconds.of(0), 0);
+    }
+  }
+
+  /****************************************************************************
+   * 
+   * Periodic actions that run every scheduler loop time (20 msec) during simulation
+   */
+  @Override
+  public void simulationPeriodic( )
+  {
+    // This method will be called once per scheduler run during simulation
+  }
+
+  /****************************************************************************
+   * 
+   * Initialize dashboard widgets
+   */
+  private void initDashboard( )
+  {
+    // Initialize dashboard widgets
+  }
+
+  // Put methods for controlling this subsystem here. Call these from Commands.
+
+  /****************************************************************************
+   * 
+   * Initialize subsystem during robot mode changes
+   */
+  public void initialize( )
+  {
+    DataLogManager.log(String.format("%s: Subsystem initialized!", getSubsystem( )));
+  }
+
+  /****************************************************************************
+   * 
+   * Write out hardware faults and reset sticky faults
+   */
+  public void printFaults( )
+  {}
+
+  ////////////////////////////////////////////////////////////////////////////
+  ///////////////////////// PRIVATE HELPERS //////////////////////////////////
+  ////////////////////////////////////////////////////////////////////////////
+
+  /****************************************************************************
+   * 
+   * Set HID driver rumble based on the requested on/off and intensity
+   * 
+   * @param rumbleOn
+   *          request rumble on or off
+   * @param duration
+   *          request a time for the rumble to last
+   * @param intensity
+   *          requested rumble strength
+   */
+  private void setHIDRumbleDriver(boolean rumbleOn, Time duration, double intensity)
+  {
+    DataLogManager
+        .log(String.format("%s: Rumble driver: %s duration %s intensity: %.1f", getName( ), rumbleOn, duration, intensity));
+
+    if (rumbleOn)
+    {
+      m_timerDriver.restart( );
+      m_driverDuration = duration;
+    }
+
+    m_driver.setRumble(RumbleType.kBothRumble, (rumbleOn) ? intensity : 0.0);
+  }
+
+  /****************************************************************************
+   * 
+   * Set HID operator rumble based on the requested on/off and intensity
+   * 
+   * @param rumbleOn
+   *          request rumble on or off
+   * @param duration
+   *          request a time for the rumble to last
+   * @param intensity
+   *          requested rumble strength
+   */
+  private void setHIDRumbleOperator(boolean rumbleOn, Time duration, double intensity)
+  {
+    DataLogManager
+        .log(String.format("%s Rumble operator: %s duration %s intensity: %.1f", getName( ), rumbleOn, duration, intensity));
+
+    if (rumbleOn)
+    {
+      m_timerOperator.restart( );
+      m_operatorDuration = duration;
+    }
+
+    m_operator.setRumble(RumbleType.kBothRumble, (rumbleOn) ? intensity : 0.0);
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  ///////////////////////// COMMAND FACTORIES ////////////////////////////////
+  ////////////////////////////////////////////////////////////////////////////
+
+  /****************************************************************************
+   * 
+   * Create HID set rumble for driver controller command
+   * 
+   * @param driverRumble
+   *          rumble the driver gamepad
+   * @param duration
+   *          request a time for the rumble to last
+   * @param intensity
+   *          stength of the rumble [0.0 .. 1.0]
+   * @return instant command that rumbles the gamepad
+   */
+  public Command getHIDRumbleDriverCommand(boolean driverRumble, Time duration, double intensity)
+  {
+
+    return new InstantCommand(                                        // Command that runs exactly once
+        ( ) -> setHIDRumbleDriver(driverRumble, duration, intensity), // Method to call
+        this                                                          // Command that runs exactly once
+    ).withName("HIDRumbleDriver").ignoringDisable(true);
+  }
+
+  /****************************************************************************
+   * 
+   * Create HID set rumble for operator controller command
+   * 
+   * @param operatorRumble
+   *          rumble the operator gamepad
+   * @param duration
+   *          request a time for the rumble to last
+   * @param intensity
+   *          stength of the rumble [0.0 .. 1.0]
+   * @return instant command that rumbles the gamepad
+   */
+  public Command getHIDRumbleOperatorCommand(boolean operatorRumble, Time duration, double intensity)
+  {
+
+    return new InstantCommand(                                            // Command that runs exactly once
+        ( ) -> setHIDRumbleOperator(operatorRumble, duration, intensity), // Method to call
+        this                                                              // Command that runs exactly once
+    ).withName("HIDRumbleOperator").ignoringDisable(true);
+  }
+}


### PR DESCRIPTION
HID subsystem added to Comp2025 subsystems.

## Description (What changed)
HID class added to subsystems section of Comp 2025 code. HID subsystem object and functionality added to Robot Container. 

## Motivation and Context (Why needed)
This change allows robot commands to use the rumble on the game controllers. 

## How has this been tested?
The HID rumble has been tested using the widgets and logs in simulation. The hid command was run using a SmartDashboard widget, and the log messages showed the correct messages. The change does not affect any other current subsystems. 
- [x] Compiles with no errors and no ***additional*** warnings
- [x] Simulates without crashes, errors or warnings
- [x] Simulates with the change under test successfully working
- [ ] Tested in the robot with no crashes, errors or warnings
- [x] I verified the log messages were as expected with no warnings in AdvantageScope

## Screenshots (optional: if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The auto-formatter was working correctly when submitted
- [x] I have updated any comments accordingly.
