### PR TITLE
Inverted Elevator motor directions

### DIFF
--- a/Comp2025/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/Comp2025/src/main/java/frc/robot/subsystems/Elevator.java
@@ -178,10 +178,10 @@ public class Elevator extends SubsystemBase
 
     // Initialize motor objects
     boolean leftValid = PhoenixUtil6.getInstance( ).talonFXInitialize6(m_leftMotor, kSubsystemName + "Left",
-        CTREConfigs6.elevatorFXConfig(false, Conversions.inchesToWinchRotations(kHeightInchesMin, kRolloutRatio),
+        CTREConfigs6.elevatorFXConfig(true, Conversions.inchesToWinchRotations(kHeightInchesMin, kRolloutRatio),
             Conversions.inchesToWinchRotations(kHeightInchesMax, kRolloutRatio)));
     boolean rightValid = PhoenixUtil6.getInstance( ).talonFXInitialize6(m_rightMotor, kSubsystemName + "Right",
-        CTREConfigs6.elevatorFXConfig(true, Conversions.inchesToWinchRotations(kHeightInchesMin, kRolloutRatio),
+        CTREConfigs6.elevatorFXConfig(false, Conversions.inchesToWinchRotations(kHeightInchesMin, kRolloutRatio),
             Conversions.inchesToWinchRotations(kHeightInchesMax, kRolloutRatio)));
     m_motorsValid = leftValid && rightValid;
 


### PR DESCRIPTION
The two elevator motors have inverted directions. 

## Motivation and Context (Why needed)
The direction of the motors did not correspond with the direction of the joystick. The new changes fix this. 
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
The change has been tested on the practice robot. This affects no other subsystems. 
- [x] Compiles with no errors and no ***additional*** warnings
- [ ] Simulates without crashes, errors or warnings
- [ ] Simulates with the change under test successfully working
- [x] Tested in the robot with no crashes, errors or warnings
- [x] I verified the log messages were as expected with no warnings in AdvantageScope

## Screenshots (optional: if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The auto-formatter was working correctly when submitted
- [x] I have updated any comments accordingly.
