### PR TITLE
Revert PathPlanner AutoBuilder path following PID constants

### DIFF
--- a/Comp2025/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/Comp2025/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -260,9 +260,9 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
                 ),
                 new PPHolonomicDriveController(
                     // PID constants for translation
-                    new PIDConstants(25, 0, 0),
+                    new PIDConstants(10, 0, 0),
                     // PID constants for rotation
-                    new PIDConstants(10, 0, 0)
+                    new PIDConstants(7, 0, 0)
                 ),
                 config,
                 // Assume the path needs to be flipped for Red vs Blue, this is normally the case


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
Reduce AutoBuilder path following PID constants back to defaults from Apollo aggressive settings

## Description (What changed)
<!--- Describe your changes in detail -->
AutoBuilder PID settings changed from 25, 0, 10 back to 10, 0 7 (P, I, D).

## Motivation and Context (Why needed)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Apollo (2024 robot) used very aggressive PID settings in the path following control loop to attempt to improve path accuracy. Since the Comp2025 project ported these settings over, they need to be reverted back the CTRE defaults until tuned again.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Compiles with no errors and no ***additional*** warnings
- [x] Simulates without crashes, errors or warnings
- [ x Simulates with the change under test successfully working
- [ ] Tested in the robot with no crashes, errors or warnings
- [x] I verified the log messages were as expected with no warnings in AdvantageScope

## Screenshots (optional: if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The auto-formatter was working correctly when submitted
- [x] I have updated any comments accordingly.
