### PR TITLE
Create manipulator claw speeds

### DIFF
--- a/Comp2025/src/main/java/frc/robot/Constants.java
+++ b/Comp2025/src/main/java/frc/robot/Constants.java
@@ -97,12 +97,16 @@ public class Constants
     /** Manipulator claw roller modes */
     public enum ClawMode
     {
-      STOP,       // Stop all rotation
-      ACQUIRE,    // Speed for acquiring a game piece
-      EXPEL,      // Speed for expelling a game piece
-      SHOOT,      // Speed for shooting a game piece
-      PROCESSOR,  // Speed for putting game piece into processor 
-      HOLD        // Maintain existing speed setting
+      STOP,             // Stop all rotation
+      ALGAEACQUIRE,     // Speed for acquiring algae
+      ALGAEEXPEL,       // Speed for expelling algae
+      ALGAESHOOT,       // Speed for shooting algae
+      ALGAEPROCESSOR,   // Speed for putting algae into processor 
+      ALGAEHOLD,        // Maintain existing speed setting
+
+      CORALACQUIRE,     // Speed for acquiring coral
+      CORALEXPEL,       // Speed for expelling coral
+      CORALHOLD         // Maintain existing speed setting
     }
   }
 

--- a/Comp2025/src/main/java/frc/robot/Constants.java
+++ b/Comp2025/src/main/java/frc/robot/Constants.java
@@ -92,7 +92,7 @@ public class Constants
   /****************************************************************************
    * Manipulator subsystem constants
    ****************************************************************************/
-  public static final class CRConsts
+  public static final class CRConsts // Claw roller
   {
     /** Manipulator claw roller modes */
     public enum ClawMode

--- a/Comp2025/src/main/java/frc/robot/subsystems/Manipulator.java
+++ b/Comp2025/src/main/java/frc/robot/subsystems/Manipulator.java
@@ -68,18 +68,21 @@ import frc.robot.lib.phoenix.PhoenixUtil6;
 public class Manipulator extends SubsystemBase
 {
   // Constants
-  private static final String  kSubsystemName        = "Manipulator";
+  private static final String  kSubsystemName             = "Manipulator";
 
-  private static final double  kClawSpeedAcquire     = 0.5;
-  private static final double  kClawSpeedExpel       = -0.4;
-  private static final double  kClawSpeedToShoot     = -1.0;
-  private static final double  kClawSpeedToProcessor = -0.4;
-  private static final double  kClawSpeedHold        = 0.1;
+  private static final double  kAlgaeClawSpeedAcquire     = 0.5;
+  private static final double  kAlgaeClawSpeedExpel       = -0.4;
+  private static final double  kAlgaeClawSpeedToShoot     = -1.0;
+  private static final double  kAlgaeClawSpeedToProcessor = -0.4;
+  private static final double  kAlgaeClawSpeedHold        = 0.1;
 
-  private static final double  kWristGearRatio       = 49.23;
-  private static final double  kWristLengthMeters    = Units.inchesToMeters(15); // Simulation
-  private static final double  kWristWeightKg        = Units.lbsToKilograms(20.0);  // Simulation
-  private static final Voltage kWristManualVolts     = Volts.of(3.5);         // Motor voltage during manual operation (joystick)
+  private static final double  kCoralClawSpeedAcquire     = 0.5;
+  private static final double  kCoralClawSpeedExpel       = -0.5;
+
+  private static final double  kWristGearRatio            = 49.23;
+  private static final double  kWristLengthMeters         = Units.inchesToMeters(15); // Simulation
+  private static final double  kWristWeightKg             = Units.lbsToKilograms(20.0);  // Simulation
+  private static final Voltage kWristManualVolts          = Volts.of(3.5);         // Motor voltage during manual operation (joystick)
 
   /** Wrist rotary motor manual move parameters */
   private enum WristMode
@@ -101,21 +104,19 @@ public class Manipulator extends SubsystemBase
   //      Comp     -177.3  -176.3     -124.7    24.9      25.8
   //      Practice -177.8  -176.8     -124.7    27.3      27.4
   private static final double       kWristAngleRetracted      = Robot.isComp( ) ? -176.3 : -176.8;  // One degree from hardstops
-  private static final double       kWristAngleDeployed       = Robot.isComp( ) ? 24.9 : 27.3;      //
+  // private static final double       kWristAngleDeployed       = Robot.isComp( ) ? 24.9 : 27.3;    Currently being kept for reference
 
-  private static final double       kWristAngleStowed         = 0;
   private static final double       kWristAngleCoralL1        = 0;
   private static final double       kWristAngleCoralL23       = 0;
   private static final double       kWristAngleCoralL4        = 0;
   private static final double       kWristAngleCoralStation   = 0;
 
-  private static final double       kWristAngleAlgaeL23       = 0;
-  private static final double       kWristAngleAlgaeL34       = 0;
+  private static final double       kWristAngleAlgaeReef      = 0;
   private static final double       kWristAngleAlgaeProcessor = 0;
   private static final double       kWristAngleAlgaeNet       = 0;
 
-  private static final double       kWristAngleMin            = kWristAngleRetracted;
-  private static final double       kWristAngleMax            = kWristAngleDeployed;
+  private static final double       kWristAngleMin            = kWristAngleRetracted - 3.0;
+  private static final double       kWristAngleMax            = kWristAngleAlgaeReef + 3.0;
 
   // Device objects
   private final TalonFX             m_wristMotor              = new TalonFX(Ports.kCANID_WristRotary);
@@ -311,14 +312,25 @@ public class Manipulator extends SubsystemBase
 
     // Add commands
     SmartDashboard.putData("MNClawStop", getMoveToPositionCommand(ClawMode.STOP, this::getCurrentPosition));
-    SmartDashboard.putData("MNClawAcquire", getMoveToPositionCommand(ClawMode.ACQUIRE, this::getCurrentPosition));
-    SmartDashboard.putData("MNClawExpel", getMoveToPositionCommand(ClawMode.EXPEL, this::getCurrentPosition));
-    SmartDashboard.putData("MNClawShoot", getMoveToPositionCommand(ClawMode.SHOOT, this::getCurrentPosition));
-    SmartDashboard.putData("MNClawHandoff", getMoveToPositionCommand(ClawMode.PROCESSOR, this::getCurrentPosition));
-    SmartDashboard.putData("MNClawHold", getMoveToPositionCommand(ClawMode.HOLD, this::getCurrentPosition));
+    SmartDashboard.putData("MNAlgaeClawAcquire", getMoveToPositionCommand(ClawMode.ALGAEACQUIRE, this::getCurrentPosition));
+    SmartDashboard.putData("MNAlgaeClawExpel", getMoveToPositionCommand(ClawMode.ALGAEEXPEL, this::getCurrentPosition));
+    SmartDashboard.putData("MNAlgaeClawShoot", getMoveToPositionCommand(ClawMode.ALGAESHOOT, this::getCurrentPosition));
+    SmartDashboard.putData("MNAlgaeClawHandoff", getMoveToPositionCommand(ClawMode.ALGAEPROCESSOR, this::getCurrentPosition));
+    SmartDashboard.putData("MNAlgaeClawHold", getMoveToPositionCommand(ClawMode.ALGAEHOLD, this::getCurrentPosition));
 
-    SmartDashboard.putData("MNWristRetract", getMoveToPositionCommand(ClawMode.HOLD, this::getManipulatorRetracted));
+    SmartDashboard.putData("MNCoralClawAcquire", getMoveToPositionCommand(ClawMode.CORALACQUIRE, this::getCurrentPosition));
+    SmartDashboard.putData("MNCoralClawExpel", getMoveToPositionCommand(ClawMode.CORALEXPEL, this::getCurrentPosition));
+    SmartDashboard.putData("MNCoralClawHold", getMoveToPositionCommand(ClawMode.CORALHOLD, this::getCurrentPosition));
 
+    SmartDashboard.putData("MNWristRetract", getMoveToPositionCommand(ClawMode.CORALHOLD, this::getManipulatorRetracted));
+    SmartDashboard.putData("MNWristAngleCoral1", getMoveToPositionCommand(ClawMode.CORALHOLD, this::getManipulatorCoralL1));
+    SmartDashboard.putData("MNWristAngleCoral23", getMoveToPositionCommand(ClawMode.CORALHOLD, this::getManipulatorCoralL23));
+    SmartDashboard.putData("MNWristAngleCoral4", getMoveToPositionCommand(ClawMode.CORALHOLD, this::getManipulatorCoralL4));
+
+    SmartDashboard.putData("MNWristAngleAlgaeReef", getMoveToPositionCommand(ClawMode.CORALHOLD, this::getManipulatorAlgaeReef));
+    SmartDashboard.putData("MNWristAngleAlgaeNet", getMoveToPositionCommand(ClawMode.CORALHOLD, this::getManipulatorAlgaeNet));
+    SmartDashboard.putData("MNWristAngleAlgaeProcessor",
+        getMoveToPositionCommand(ClawMode.CORALHOLD, this::getManipulatorAlgaeProcessor));
   }
 
   // Put methods for controlling this subsystem here. Call these from Commands.
@@ -503,7 +515,7 @@ public class Manipulator extends SubsystemBase
   {
     double output = 0.0;
 
-    if (mode == ClawMode.HOLD)
+    if (mode == ClawMode.ALGAEHOLD || mode == ClawMode.CORALHOLD)
     {
       DataLogManager.log(String.format("%s: Claw mode is unchanged - %s (%.3f)", getSubsystem( ), mode, m_clawMotor.get( )));
     }
@@ -514,19 +526,26 @@ public class Manipulator extends SubsystemBase
         default :
           DataLogManager.log(String.format("%s: Claw mode is invalid: %s", getSubsystem( ), mode));
         case STOP :
-          output = (m_algaeDetected) ? kClawSpeedHold : 0.0;
+          output = (m_algaeDetected) ? kAlgaeClawSpeedHold : 0.0;
           break;
-        case ACQUIRE :
-          output = kClawSpeedAcquire;
+        case ALGAEACQUIRE :
+          output = kAlgaeClawSpeedAcquire;
           break;
-        case EXPEL :
-          output = kClawSpeedExpel;
+        case ALGAEEXPEL :
+          output = kAlgaeClawSpeedExpel;
           break;
-        case SHOOT :
-          output = kClawSpeedToShoot;
+        case ALGAESHOOT :
+          output = kAlgaeClawSpeedToShoot;
           break;
-        case PROCESSOR :
-          output = kClawSpeedToProcessor;
+        case ALGAEPROCESSOR :
+          output = kAlgaeClawSpeedToProcessor;
+          break;
+        case CORALACQUIRE :
+          output = kCoralClawSpeedAcquire;
+          break;
+        case CORALEXPEL :
+          output = kCoralClawSpeedExpel;
+          break;
       }
       DataLogManager.log(String.format("%s: Claw mode is now - %s", getSubsystem( ), mode));
       m_clawMotor.set(output);
@@ -584,28 +603,6 @@ public class Manipulator extends SubsystemBase
 
   /****************************************************************************
    * 
-   * Return manipulator angle for deployed state
-   * 
-   * @return deployed state angle
-   */
-  public double getManipulatorDeployed( )
-  {
-    return kWristAngleDeployed;
-  }
-
-  /****************************************************************************
-   * 
-   * Return manipulator angle for stowed state
-   * 
-   * @return deployed state angle
-   */
-  public double getManipulatorStowed( )
-  {
-    return kWristAngleStowed;
-  }
-
-  /****************************************************************************
-   * 
    * Return manipulator angle for coral level 1 state
    * 
    * @return deployed state angle
@@ -654,20 +651,9 @@ public class Manipulator extends SubsystemBase
    * 
    * @return deployed state angle
    */
-  public double getManipulatorAlgaeL23( )
+  public double getManipulatorAlgaeReef( )
   {
-    return kWristAngleAlgaeL23;
-  }
-
-  /****************************************************************************
-   * 
-   * Return manipulator angle for algae level 34 state
-   * 
-   * @return deployed state angle
-   */
-  public double getManipulatorAlgaeL34( )
-  {
-    return kWristAngleAlgaeL34;
+    return kWristAngleAlgaeReef;
   }
 
   /****************************************************************************

--- a/Comp2025/src/main/java/frc/robot/subsystems/Manipulator.java
+++ b/Comp2025/src/main/java/frc/robot/subsystems/Manipulator.java
@@ -115,8 +115,8 @@ public class Manipulator extends SubsystemBase
   private static final double       kWristAngleAlgaeProcessor = 0;
   private static final double       kWristAngleAlgaeNet       = 0;
 
-  private static final double       kWristAngleMin            = kWristAngleRetracted - 3.0;
-  private static final double       kWristAngleMax            = kWristAngleAlgaeReef + 3.0;
+  private static final double       kWristAngleMin            = kWristAngleRetracted;
+  private static final double       kWristAngleMax            = kWristAngleAlgaeReef;
 
   // Device objects
   private final TalonFX             m_wristMotor              = new TalonFX(Ports.kCANID_WristRotary);

--- a/Comp2025/src/main/java/frc/robot/subsystems/Manipulator.java
+++ b/Comp2025/src/main/java/frc/robot/subsystems/Manipulator.java
@@ -68,21 +68,21 @@ import frc.robot.lib.phoenix.PhoenixUtil6;
 public class Manipulator extends SubsystemBase
 {
   // Constants
-  private static final String  kSubsystemName         = "Manipulator";
+  private static final String  kSubsystemName       = "Manipulator";
 
-  private static final double  kAlgaeSpeedAcquire     = 0.5;
-  private static final double  kAlgaeSpeedExpel       = -0.4;
-  private static final double  kAlgaeSpeedToShoot     = -1.0;
-  private static final double  kAlgaeSpeedToProcessor = -0.4;
-  private static final double  kAlgaeSpeedHold        = 0.1;
+  private static final double  kAlgaeSpeedAcquire   = 0.5;
+  private static final double  kAlgaeSpeedExpel     = -0.4;
+  private static final double  kAlgaeSpeedShoot     = -1.0;
+  private static final double  kAlgaeSpeedProcessor = -0.4;
+  private static final double  kAlgaeSpeedHold      = 0.1;
 
-  private static final double  kCoralSpeedAcquire     = 0.5;
-  private static final double  kCoralSpeedExpel       = -0.5;
+  private static final double  kCoralSpeedAcquire   = 0.5;
+  private static final double  kCoralSpeedExpel     = -0.5;
 
-  private static final double  kWristGearRatio        = 49.23;
-  private static final double  kWristLengthMeters     = Units.inchesToMeters(15); // Simulation
-  private static final double  kWristWeightKg         = Units.lbsToKilograms(20.0);  // Simulation
-  private static final Voltage kWristManualVolts      = Volts.of(3.5);         // Motor voltage during manual operation (joystick)
+  private static final double  kWristGearRatio      = 49.23;
+  private static final double  kWristLengthMeters   = Units.inchesToMeters(15); // Simulation
+  private static final double  kWristWeightKg       = Units.lbsToKilograms(20.0);  // Simulation
+  private static final Voltage kWristManualVolts    = Volts.of(3.5);         // Motor voltage during manual operation (joystick)
 
   /** Wrist rotary motor manual move parameters */
   private enum WristMode
@@ -535,10 +535,10 @@ public class Manipulator extends SubsystemBase
           output = kAlgaeSpeedExpel;
           break;
         case ALGAESHOOT :
-          output = kAlgaeSpeedToShoot;
+          output = kAlgaeSpeedShoot;
           break;
         case ALGAEPROCESSOR :
-          output = kAlgaeSpeedToProcessor;
+          output = kAlgaeSpeedProcessor;
           break;
         case CORALACQUIRE :
           output = kCoralSpeedAcquire;

--- a/Comp2025/src/main/java/frc/robot/subsystems/Manipulator.java
+++ b/Comp2025/src/main/java/frc/robot/subsystems/Manipulator.java
@@ -106,17 +106,19 @@ public class Manipulator extends SubsystemBase
   private static final double       kWristAngleRetracted      = Robot.isComp( ) ? -176.3 : -176.8;  // One degree from hardstops
   // private static final double       kWristAngleDeployed       = Robot.isComp( ) ? 24.9 : 27.3;    Currently being kept for reference
 
-  private static final double       kWristAngleCoralL1        = 0;
-  private static final double       kWristAngleCoralL23       = 0;
-  private static final double       kWristAngleCoralL4        = 0;
-  private static final double       kWristAngleCoralStation   = 0;
+  private static final double       kWristAngleCoralL1        = 0.0;
+  private static final double       kWristAngleCoralL2        = 0.0;
+  private static final double       kWristAngleCoralL3        = 0.0;
+  private static final double       kWristAngleCoralL4        = 0.0;
+  private static final double       kWristAngleCoralStation   = 0.0;
 
-  private static final double       kWristAngleAlgaeReef      = 0;
-  private static final double       kWristAngleAlgaeProcessor = 0;
-  private static final double       kWristAngleAlgaeNet       = 0;
+  private static final double       kWristAngleAlgae23        = 0.0;
+  private static final double       kWristAngleAlgae34        = 0.0;
+  private static final double       kWristAngleAlgaeProcessor = 0.0;
+  private static final double       kWristAngleAlgaeNet       = 0.0;
 
-  private static final double       kWristAngleMin            = kWristAngleRetracted;
-  private static final double       kWristAngleMax            = kWristAngleAlgaeReef;
+  private static final double       kWristAngleMin            = 0.0; //TODO: Complete with Correct Angles 
+  private static final double       kWristAngleMax            = 0.0; // TODO: Complete with Correct Angles
 
   // Device objects
   private final TalonFX             m_wristMotor              = new TalonFX(Ports.kCANID_WristRotary);
@@ -324,10 +326,12 @@ public class Manipulator extends SubsystemBase
 
     SmartDashboard.putData("MNWristRetract", getMoveToPositionCommand(ClawMode.CORALHOLD, this::getManipulatorRetracted));
     SmartDashboard.putData("MNWristAngleCoral1", getMoveToPositionCommand(ClawMode.CORALHOLD, this::getManipulatorCoralL1));
-    SmartDashboard.putData("MNWristAngleCoral23", getMoveToPositionCommand(ClawMode.CORALHOLD, this::getManipulatorCoralL23));
+    SmartDashboard.putData("MNWristAngleCoral2", getMoveToPositionCommand(ClawMode.CORALHOLD, this::getManipulatorCoralL2));
+    SmartDashboard.putData("MNWristAngleCoral3", getMoveToPositionCommand(ClawMode.CORALHOLD, this::getManipulatorCoralL3));
     SmartDashboard.putData("MNWristAngleCoral4", getMoveToPositionCommand(ClawMode.CORALHOLD, this::getManipulatorCoralL4));
 
-    SmartDashboard.putData("MNWristAngleAlgaeReef", getMoveToPositionCommand(ClawMode.CORALHOLD, this::getManipulatorAlgaeReef));
+    SmartDashboard.putData("MNWristAngleAlgae23", getMoveToPositionCommand(ClawMode.CORALHOLD, this::getManipulatorAlgae23));
+    SmartDashboard.putData("MNWristAngleAlgae34", getMoveToPositionCommand(ClawMode.CORALHOLD, this::getManipulatorAlgae34));
     SmartDashboard.putData("MNWristAngleAlgaeNet", getMoveToPositionCommand(ClawMode.CORALHOLD, this::getManipulatorAlgaeNet));
     SmartDashboard.putData("MNWristAngleAlgaeProcessor",
         getMoveToPositionCommand(ClawMode.CORALHOLD, this::getManipulatorAlgaeProcessor));
@@ -614,13 +618,24 @@ public class Manipulator extends SubsystemBase
 
   /****************************************************************************
    * 
-   * Return manipulator angle for coral level 2 and 3 state
+   * Return manipulator angle for coral level 2 state
    * 
    * @return deployed state angle
    */
-  public double getManipulatorCoralL23( )
+  public double getManipulatorCoralL2( )
   {
-    return kWristAngleCoralL23;
+    return kWristAngleCoralL2;
+  }
+
+  /****************************************************************************
+   * 
+   * Return manipulator angle for coral level 3 state
+   * 
+   * @return deployed state angle
+   */
+  public double getManipulatorCoralL3( )
+  {
+    return kWristAngleCoralL3;
   }
 
   /****************************************************************************
@@ -651,9 +666,20 @@ public class Manipulator extends SubsystemBase
    * 
    * @return deployed state angle
    */
-  public double getManipulatorAlgaeReef( )
+  public double getManipulatorAlgae23( )
   {
-    return kWristAngleAlgaeReef;
+    return kWristAngleAlgae23;
+  }
+
+  /****************************************************************************
+   * 
+   * Return manipulator angle for algae level 34 state
+   * 
+   * @return deployed state angle
+   */
+  public double getManipulatorAlgae34( )
+  {
+    return kWristAngleAlgae34;
   }
 
   /****************************************************************************

--- a/Comp2025/src/main/java/frc/robot/subsystems/Manipulator.java
+++ b/Comp2025/src/main/java/frc/robot/subsystems/Manipulator.java
@@ -68,21 +68,21 @@ import frc.robot.lib.phoenix.PhoenixUtil6;
 public class Manipulator extends SubsystemBase
 {
   // Constants
-  private static final String  kSubsystemName             = "Manipulator";
+  private static final String  kSubsystemName         = "Manipulator";
 
-  private static final double  kAlgaeClawSpeedAcquire     = 0.5;
-  private static final double  kAlgaeClawSpeedExpel       = -0.4;
-  private static final double  kAlgaeClawSpeedToShoot     = -1.0;
-  private static final double  kAlgaeClawSpeedToProcessor = -0.4;
-  private static final double  kAlgaeClawSpeedHold        = 0.1;
+  private static final double  kAlgaeSpeedAcquire     = 0.5;
+  private static final double  kAlgaeSpeedExpel       = -0.4;
+  private static final double  kAlgaeSpeedToShoot     = -1.0;
+  private static final double  kAlgaeSpeedToProcessor = -0.4;
+  private static final double  kAlgaeSpeedHold        = 0.1;
 
-  private static final double  kCoralClawSpeedAcquire     = 0.5;
-  private static final double  kCoralClawSpeedExpel       = -0.5;
+  private static final double  kCoralSpeedAcquire     = 0.5;
+  private static final double  kCoralSpeedExpel       = -0.5;
 
-  private static final double  kWristGearRatio            = 49.23;
-  private static final double  kWristLengthMeters         = Units.inchesToMeters(15); // Simulation
-  private static final double  kWristWeightKg             = Units.lbsToKilograms(20.0);  // Simulation
-  private static final Voltage kWristManualVolts          = Volts.of(3.5);         // Motor voltage during manual operation (joystick)
+  private static final double  kWristGearRatio        = 49.23;
+  private static final double  kWristLengthMeters     = Units.inchesToMeters(15); // Simulation
+  private static final double  kWristWeightKg         = Units.lbsToKilograms(20.0);  // Simulation
+  private static final Voltage kWristManualVolts      = Volts.of(3.5);         // Motor voltage during manual operation (joystick)
 
   /** Wrist rotary motor manual move parameters */
   private enum WristMode
@@ -526,25 +526,25 @@ public class Manipulator extends SubsystemBase
         default :
           DataLogManager.log(String.format("%s: Claw mode is invalid: %s", getSubsystem( ), mode));
         case STOP :
-          output = (m_algaeDetected) ? kAlgaeClawSpeedHold : 0.0;
+          output = (m_algaeDetected) ? kAlgaeSpeedHold : 0.0;
           break;
         case ALGAEACQUIRE :
-          output = kAlgaeClawSpeedAcquire;
+          output = kAlgaeSpeedAcquire;
           break;
         case ALGAEEXPEL :
-          output = kAlgaeClawSpeedExpel;
+          output = kAlgaeSpeedExpel;
           break;
         case ALGAESHOOT :
-          output = kAlgaeClawSpeedToShoot;
+          output = kAlgaeSpeedToShoot;
           break;
         case ALGAEPROCESSOR :
-          output = kAlgaeClawSpeedToProcessor;
+          output = kAlgaeSpeedToProcessor;
           break;
         case CORALACQUIRE :
-          output = kCoralClawSpeedAcquire;
+          output = kCoralSpeedAcquire;
           break;
         case CORALEXPEL :
-          output = kCoralClawSpeedExpel;
+          output = kCoralSpeedExpel;
           break;
       }
       DataLogManager.log(String.format("%s: Claw mode is now - %s", getSubsystem( ), mode));


### PR DESCRIPTION
The speeds for the coral and algae modes has been added to the manipulator. 

## Description (What changed)
In addition to the set speeds and usages for the algae manipulator in the claw, the speeds and usages for the coral have also been implemented. 

## Motivation and Context (Why needed)
The change was required for the manipulator subsystem to be able to manipulate both the coral and algae game pieces. 

## How has this been tested?
The changes have been tested on the prototype manipulator. The different set speeds were tested on the coral and the algae. The code gave the expected results and worked. This code does not affect other subsystems. 
- [x] Compiles with no errors and no ***additional*** warnings
- [x] Simulates without crashes, errors or warnings
- [x] Simulates with the change under test successfully working
- [x] Tested in the robot with no crashes, errors or warnings
- [x] I verified the log messages were as expected with no warnings in AdvantageScope

## Screenshots (optional: if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The auto-formatter was working correctly when submitted
- [x] I have updated any comments accordingly.
