### PR TITLE
Use WPILib field poses for 2025 AprilTags

### DIFF
--- a/Comp2025/src/main/java/frc/robot/Constants.java
+++ b/Comp2025/src/main/java/frc/robot/Constants.java
@@ -4,6 +4,8 @@ package frc.robot;
 import java.util.Collections;
 import java.util.List;
 
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.apriltag.AprilTagFields;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
@@ -111,30 +113,12 @@ public class Constants
    ****************************************************************************/
   public static final class VIConsts
   {
-    /** Field locations (poses) of AprilTags */
-    public static final List<Pose2d> kAprilTagPoses = Collections.unmodifiableList(List.of(           // TODO: update for 2025 from Field layout and marking diagram
-        new Pose2d(new Translation2d(0.0, 0.0), Rotation2d.fromDegrees(0)),               // AprilTag ID: 0 (invalid)
-        new Pose2d(new Translation2d(15.079472, 0.245872), Rotation2d.fromDegrees(120)),  // AprilTag ID: 1   - Blue source right
-        new Pose2d(new Translation2d(16.185134, 0.883666), Rotation2d.fromDegrees(120)),  // AprilTag ID: 2   - Blue source left
-        new Pose2d(new Translation2d(16.579342, 4.982718), Rotation2d.fromDegrees(180)),  // AprilTag ID: 3   - Red speaker right
-        new Pose2d(new Translation2d(16.579342, 5.547868), Rotation2d.fromDegrees(180)),  // AprilTag ID: 4   - Red speaker center
-        new Pose2d(new Translation2d(14.700758, 8.2042), Rotation2d.fromDegrees(270)),    // AprilTag ID: 5   - Red amp
-        new Pose2d(new Translation2d(1.8415, 8.20426), Rotation2d.fromDegrees(270)),      // AprilTag ID: 6   - Blue amp
-        new Pose2d(new Translation2d(-0.0381, 5.547868), Rotation2d.fromDegrees(0)),        // AprilTag ID: 7   - Blue speaker center
-        new Pose2d(new Translation2d(-0.0381, 4.982718), Rotation2d.fromDegrees(0)),        // AprilTag ID: 8   - Blue speker left
-        new Pose2d(new Translation2d(0.356108, 0.883666), Rotation2d.fromDegrees(60)),    // AprilTag ID: 9   - Red source right
-        new Pose2d(new Translation2d(1.461516, 0.245872), Rotation2d.fromDegrees(60)),    // AprilTag ID: 10  - Red source left
-        new Pose2d(new Translation2d(11.904726, 3.713226), Rotation2d.fromDegrees(300)),  // AprilTag ID: 11  - Red stage left
-        new Pose2d(new Translation2d(11.904726, 4.49834), Rotation2d.fromDegrees(60)),    // AprilTag ID: 12  - Red stage right
-        new Pose2d(new Translation2d(11.220196, 4.105148), Rotation2d.fromDegrees(180)),  // AprilTag ID: 13  - Red stage center
-        new Pose2d(new Translation2d(5.320792, 4.105148), Rotation2d.fromDegrees(0)),     // AprilTag ID: 14  - Blue stage center
-        new Pose2d(new Translation2d(4.641342, 4.49834), Rotation2d.fromDegrees(120)),    // AprilTag ID: 15  - Blue stage left
-        new Pose2d(new Translation2d(4.641342, 3.713226), Rotation2d.fromDegrees(240))    // AprilTag ID: 16  - Blue stage right
-    ));
+    public static final AprilTagFields      kGameField   = AprilTagFields.k2025Reefscape;
+    public static final AprilTagFieldLayout kATField     = AprilTagFieldLayout.loadField(kGameField);
 
     /** Destination field poses for the robot when using PathPlanner pathfinding */                   // TODO: update to desired 2025 field poses
-    public static final Pose2d       kSpeakerPose   = new Pose2d(2.17, 4.49, Rotation2d.fromDegrees(-26));
-    public static final Pose2d       kAmpPose       = new Pose2d(1.84, 7.77, Rotation2d.fromDegrees(-90));
+    public static final Pose2d              kSpeakerPose = new Pose2d(2.17, 4.49, Rotation2d.fromDegrees(-26));
+    public static final Pose2d              kAmpPose     = new Pose2d(1.84, 7.77, Rotation2d.fromDegrees(-90));
   }
 
   /****************************************************************************

--- a/Comp2025/src/main/java/frc/robot/RobotContainer.java
+++ b/Comp2025/src/main/java/frc/robot/RobotContainer.java
@@ -22,6 +22,8 @@ import com.ctre.phoenix6.swerve.utility.PhoenixPIDController;
 import com.pathplanner.lib.commands.PathPlannerAuto;
 import com.pathplanner.lib.path.PathPlannerPath;
 
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.apriltag.AprilTagFields;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.units.measure.AngularVelocity;
@@ -46,9 +48,9 @@ import frc.robot.commands.LogCommand;
 import frc.robot.generated.TunerConstants;
 import frc.robot.subsystems.CommandSwerveDrivetrain;
 import frc.robot.subsystems.Elevator;
-import frc.robot.subsystems.Manipulator;
 import frc.robot.subsystems.HID;
 import frc.robot.subsystems.LED;
+import frc.robot.subsystems.Manipulator;
 import frc.robot.subsystems.Power;
 import frc.robot.subsystems.Telemetry;
 import frc.robot.subsystems.Vision;
@@ -163,6 +165,13 @@ public class RobotContainer
     Robot.timeMarker("robotContainer: before DAQ thread");
     // Swerve steer PID for facing swerve request
     facing.HeadingController = new PhoenixPIDController(kHeadingKp, kHeadingKi, kHeadingKd);  // Swerve steer PID for facing swerve request
+    // Identify the field
+    DataLogManager.log(String.format("Field: %s width %.2f length %.2f", VIConsts.kGameField.toString( ),
+        VIConsts.kATField.getFieldWidth( ), VIConsts.kATField.getFieldLength( )));
+    for (int i = 1; i <= 22; i++)
+    {
+      DataLogManager.log(String.format("Field: ID %d %s", i, VIConsts.kATField.getTagPose(i)));
+    }
     // Add dashboard widgets for commands
     addDashboardWidgets( );           // Add dashboard widgets for commands
     // Configure game controller buttons


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description (What changed)
<!--- Describe your changes in detail -->
Remove 2024 AprilTag poses and replace them with 2025 Reefscape poses

## Motivation and Context (Why needed)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Need 2025 poses for driving commands

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Compiles with no errors and no ***additional*** warnings
- [x] Simulates without crashes, errors or warnings
- [x] Simulates with the change under test successfully working
- [ ] Tested in the robot with no crashes, errors or warnings
- [x] I verified the log messages were as expected with no warnings in AdvantageScope

## Screenshots (optional: if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The auto-formatter was working correctly when submitted
- [x] I have updated any comments accordingly.
