### PR TITLE
Add new tunerXComp constants to Comp2025 project

### DIFF
--- a/Comp2025/src/main/java/frc/robot/generated/TunerConstants.java
+++ b/Comp2025/src/main/java/frc/robot/generated/TunerConstants.java
@@ -49,7 +49,7 @@ public class TunerConstants {
     private static final SteerMotorArrangement kSteerMotorType = SteerMotorArrangement.TalonFX_Integrated;
 
     // The remote sensor feedback type to use for the steer motors;
-    // When not Pro-licensed, FusedCANcoder/SyncCANcoder automatically fall back to RemoteCANcoder
+    // When not Pro-licensed, Fused*/Sync* automatically fall back to Remote*
     private static final SteerFeedbackType kSteerFeedbackType = SteerFeedbackType.FusedCANcoder;
 
     // The stator current at which the wheels start to slip;
@@ -77,13 +77,13 @@ public class TunerConstants {
 
     // Theoretical free speed (m/s) at 12 V applied output;
     // This needs to be tuned to your individual robot
-    public static final LinearVelocity kSpeedAt12Volts = MetersPerSecond.of(4.73);
+    public static final LinearVelocity kSpeedAt12Volts = Robot.isComp() ? MetersPerSecond.of(5.21) : MetersPerSecond.of(4.73);
 
     // Every 1 rotation of the azimuth results in kCoupleRatio drive motor turns;
     // This may need to be tuned to your individual robot
     private static final double kCoupleRatio = 3.5714285714285716;
 
-    private static final double kDriveGearRatio = 6.746031746031747;
+    private static final double kDriveGearRatio = Robot.isComp() ? 6.122448979591837 : 6.746031746031747;
     private static final double kSteerGearRatio = 21.428571428571427;
     private static final Distance kWheelRadius = Inches.of(2);
 
@@ -132,7 +132,7 @@ public class TunerConstants {
     private static final int kFrontLeftDriveMotorId = 1;
     private static final int kFrontLeftSteerMotorId = 2;
     private static final int kFrontLeftEncoderId = 3;
-    private static final Angle kFrontLeftEncoderOffset = (Robot.isComp() ? Rotations.of(-0.44189453125) : Rotations.of(0.412353515625));
+    private static final Angle kFrontLeftEncoderOffset = (Robot.isComp() ? Rotations.of(-0.462890625) : Rotations.of(0.412353515625));
     private static final boolean kFrontLeftSteerMotorInverted = true;
     private static final boolean kFrontLeftEncoderInverted = false;
 
@@ -143,7 +143,7 @@ public class TunerConstants {
     private static final int kFrontRightDriveMotorId = 4;
     private static final int kFrontRightSteerMotorId = 5;
     private static final int kFrontRightEncoderId = 6;
-    private static final Angle kFrontRightEncoderOffset = (Robot.isComp() ? Rotations.of(-0.175048828125) : Rotations.of(0.04833984375));
+    private static final Angle kFrontRightEncoderOffset = (Robot.isComp() ? Rotations.of(-0.17333984375) : Rotations.of(0.04833984375));
     private static final boolean kFrontRightSteerMotorInverted = true;
     private static final boolean kFrontRightEncoderInverted = false;
 
@@ -154,7 +154,7 @@ public class TunerConstants {
     private static final int kBackLeftDriveMotorId = 7;
     private static final int kBackLeftSteerMotorId = 8;
     private static final int kBackLeftEncoderId = 9;
-    private static final Angle kBackLeftEncoderOffset = (Robot.isComp() ? Rotations.of(-0.411376953125) : Rotations.of(0.22607421875));
+    private static final Angle kBackLeftEncoderOffset = (Robot.isComp() ? Rotations.of(-0.41064453125) : Rotations.of(0.22607421875));
     private static final boolean kBackLeftSteerMotorInverted = true;
     private static final boolean kBackLeftEncoderInverted = false;
 
@@ -165,7 +165,7 @@ public class TunerConstants {
     private static final int kBackRightDriveMotorId = 10;
     private static final int kBackRightSteerMotorId = 11;
     private static final int kBackRightEncoderId = 12;
-    private static final Angle kBackRightEncoderOffset = (Robot.isComp() ? Rotations.of(0.001220703125) : Rotations.of(-0.2314453125));
+    private static final Angle kBackRightEncoderOffset = (Robot.isComp() ? Rotations.of(0.005126953125) : Rotations.of(-0.2314453125));
     private static final boolean kBackRightSteerMotorInverted = true;
     private static final boolean kBackRightEncoderInverted = false;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description (What changed)
<!--- Describe your changes in detail -->
Merge TunerXComp values into Comp2025 TunerConstants.java.

## Motivation and Context (Why needed)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Comp robot has an L3 swerve gearing instead of L2 on practice robot.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Compiles with no errors and no ***additional*** warnings
- [x] Simulates without crashes, errors or warnings
- [x] Simulates with the change under test successfully working
- [ ] Tested in the robot with no crashes, errors or warnings
- [x] I verified the log messages were as expected with no warnings in AdvantageScope

## Screenshots (optional: if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The auto-formatter was working correctly when submitted
- [x] I have updated any comments accordingly.
