### PR TITLE
SmartDashboard Button for Calibration Added

### DIFF
--- a/Comp2025/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/Comp2025/src/main/java/frc/robot/subsystems/Elevator.java
@@ -297,6 +297,8 @@ public class Elevator extends SubsystemBase
     SmartDashboard.putData("ElRunAlgae34", getMoveToPositionCommand(this::getHeightAlgaeL34));
     SmartDashboard.putData("ElRunNet", getMoveToPositionCommand(this::getHeightAlgaeNet));
     SmartDashboard.putData("ElRunProcessor", getMoveToPositionCommand(this::getHeightAlgaeProcessor));
+
+    SmartDashboard.putData("ElCalibrate", getCalibrateHeightCommand( ));
   }
 
   // Put methods for controlling this subsystem here. Call these from Commands.


### PR DESCRIPTION
Button to Calibrate the Elevator when the limit switch does not function properly.

## Description (What changed)
Smart Dashboard button for the calibration command was added. 

## Motivation and Context (Why needed)
This change allows for the elevator to be calibrated if the limit switch fails to work during init. The calibration command can be run when the button is pressed during teleop. 

## How has this been tested?
Code does not affect other subsystems. 
- [x] Compiles with no errors and no ***additional*** warnings
- [x] Simulates without crashes, errors or warnings
- [x] Simulates with the change under test successfully working
- [ ] Tested in the robot with no crashes, errors or warnings
- [x] I verified the log messages were as expected with no warnings in AdvantageScope

## Screenshots (optional: if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The auto-formatter was working correctly when submitted
- [x] I have updated any comments accordingly.
