### PR TITLE
Remove references left over from the crescendo game

### DIFF
--- a/Comp2025/src/main/java/frc/robot/Constants.java
+++ b/Comp2025/src/main/java/frc/robot/Constants.java
@@ -113,12 +113,11 @@ public class Constants
    ****************************************************************************/
   public static final class VIConsts
   {
-    public static final AprilTagFields      kGameField   = AprilTagFields.k2025ReefscapeWelded;
-    public static final AprilTagFieldLayout kATField     = AprilTagFieldLayout.loadField(kGameField);
+    public static final AprilTagFields      kGameField = AprilTagFields.k2025ReefscapeWelded;
+    public static final AprilTagFieldLayout kATField   = AprilTagFieldLayout.loadField(kGameField);
 
     /** Destination field poses for the robot when using PathPlanner pathfinding */                   // TODO: update to desired 2025 field poses
-    public static final Pose2d              kSpeakerPose = new Pose2d(2.17, 4.49, Rotation2d.fromDegrees(-26));
-    public static final Pose2d              kAmpPose     = new Pose2d(1.84, 7.77, Rotation2d.fromDegrees(-90));
+    public static final Pose2d              kAmpPose   = new Pose2d(1.84, 7.77, Rotation2d.fromDegrees(-90));
   }
 
   /****************************************************************************

--- a/Comp2025/src/main/java/frc/robot/RobotContainer.java
+++ b/Comp2025/src/main/java/frc/robot/RobotContainer.java
@@ -115,7 +115,7 @@ public class RobotContainer
   private enum AutoChooser
   {
     AUTOSTOP,         // AutoStop - sit still, do nothing
-    AUTOLEAVE,        // Leave starting zone avoiding spikes
+    AUTOLEAVE,        // Leave starting line
     AUTOTEST          // Run a selected test auto
   }
 
@@ -288,8 +288,7 @@ public class RobotContainer
     // Xbox enums { leftX = 0, leftY = 1, leftTrigger = 2, rightTrigger = 3, rightX = 4, rightY = 5}
     // Xbox on MacOS { leftX = 0, leftY = 1, rightX = 2, rightY = 3, leftTrigger = 5, rightTrigger = 4}
     //
-    m_driverPad.leftTrigger(Constants.kTriggerThreshold)
-        .whileTrue(m_drivetrain.drivePathtoPose(m_drivetrain, VIConsts.kSpeakerPose));
+    m_driverPad.leftTrigger(Constants.kTriggerThreshold).whileTrue(new LogCommand("driverPad", "left trigger"));
     m_driverPad.rightTrigger(Constants.kTriggerThreshold).onTrue(new LogCommand("driverPad", "right trigger"));
 
     m_driverPad.leftStick( ).onTrue(new LogCommand("driverPad", "left stick"));

--- a/Comp2025/src/main/java/frc/robot/autos/AutoLeave.java
+++ b/Comp2025/src/main/java/frc/robot/autos/AutoLeave.java
@@ -17,7 +17,7 @@ public class AutoLeave extends SequentialCommandGroup
 {
   /**
    * Autonomous command to:
-   * 1 - Leave the starting zone while avoiding spike notes
+   * 1 - Leave the starting line
    * 
    * @param ppAuto
    *          list of auto paths to follow

--- a/Comp2025/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/Comp2025/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -57,7 +57,6 @@ import frc.robot.lib.LimelightHelpers;
  */
 public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Subsystem {
     private static final boolean        m_useLimelight           = true;
-    private Pose2d                      m_allianceSpeakerATPose  = new Pose2d( );
 
     /* What to publish over networktables for telemetry */
     private final NetworkTableInstance  inst                     = NetworkTableInstance.getDefault( );
@@ -325,9 +324,6 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
                 m_hasAppliedOperatorPerspective = true;
             });
         }
-        double speakerTagDistance = this.getState( ).Pose.getTranslation( ).getDistance(m_allianceSpeakerATPose.getTranslation( ));
-        shooterDistancePub.set(Units.metersToInches(speakerTagDistance));
-
         if (m_useLimelight && Robot.isReal( )) {
             visionUpdate( );
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description (What changed)
<!--- Describe your changes in detail -->
Removed comments and sample code related to Crescendo game. Left one example of pathToPose for Amp in until replaced with new feature.

## Motivation and Context (Why needed)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Several Crescendo terms were left in the code from last year that needed to be removed.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Compiles with no errors and no ***additional*** warnings
- [x] Simulates without crashes, errors or warnings
- [x] Simulates with the change under test successfully working
- [ ] Tested in the robot with no crashes, errors or warnings
- [x] I verified the log messages were as expected with no warnings in AdvantageScope

## Screenshots (optional: if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The auto-formatter was working correctly when submitted
- [x] I have updated any comments accordingly.
