### PR TITLE
Fix elevator "drum" references to use a sprocket for our elevator use

### DIFF
--- a/Comp2025/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/Comp2025/src/main/java/frc/robot/subsystems/Elevator.java
@@ -62,35 +62,35 @@ import frc.robot.lib.phoenix.PhoenixUtil6;
 public class Elevator extends SubsystemBase
 {
   // Constants
-  private static final String  kSubsystemName        = "Elevator";
-  private static final double  kGearRatio            = 9.706;           // Gear reduction
-  private static final double  kHeightInchesMin      = 0.0;             // Minimum allowable height
-  private static final double  kHeightInchesMax      = 29.69;           // Maximum allowable height
-  private static final double  kSimHeightMetersMin   = Units.inchesToMeters(kHeightInchesMin - 0.1); // Make sim height range larger than useful range
-  private static final double  kSimHeightMetersMax   = Units.inchesToMeters(kHeightInchesMax + 0.1);
-  private static final double  kCarriageMassKg       = Units.lbsToKilograms(20.0);     // Simulation
-  private static final double  kDrumDiameterInches   = 1.981;           // Drum diameter in inches
-  private static final double  kDrumRadiusMeters     = Units.inchesToMeters(kDrumDiameterInches) / 2;
-  private static final double  kRolloutRatio         = kDrumDiameterInches * Math.PI / kGearRatio; // inches per shaft rotation
-  private static final Voltage kManualSpeedVolts     = Volts.of(3.0); // Motor voltage during manual operation (joystick)
+  private static final String  kSubsystemName          = "Elevator";
+  private static final double  kGearRatio              = 9.706;           // Gear reduction
+  private static final double  kHeightInchesMin        = 0.0;             // Minimum allowable height
+  private static final double  kHeightInchesMax        = 29.69;           // Maximum allowable height
+  private static final double  kSimHeightMetersMin     = Units.inchesToMeters(kHeightInchesMin - 0.1); // Make sim height range larger than useful range
+  private static final double  kSimHeightMetersMax     = Units.inchesToMeters(kHeightInchesMax + 0.1);
+  private static final double  kCarriageMassKg         = Units.lbsToKilograms(20.0);     // Simulation
+  private static final double  kSprocketDiameterInches = 1.751;           // Sprocket diameter in inches (22T * 0.25"/T / Pi)
+  private static final double  kSprocketRadiusMeters   = Units.inchesToMeters(kSprocketDiameterInches) / 2;
+  private static final double  kRolloutRatio           = kSprocketDiameterInches * Math.PI / kGearRatio; // inches per shaft rotation
+  private static final Voltage kManualSpeedVolts       = Volts.of(3.0); // Motor voltage during manual operation (joystick)
 
-  private static final double  kToleranceInches      = 0.5;             // PID tolerance in inches
-  private static final double  kMMDebounceTime       = 0.060;           // Seconds to debounce a final position check
-  private static final double  kMMMoveTimeout        = 1.5;             // Seconds allowed for a Motion Magic movement
+  private static final double  kToleranceInches        = 0.5;             // PID tolerance in inches
+  private static final double  kMMDebounceTime         = 0.060;           // Seconds to debounce a final position check
+  private static final double  kMMMoveTimeout          = 1.5;             // Seconds allowed for a Motion Magic movement
 
   // Elevator heights - Motion Magic config parameters                  // TODO: define desired elevator heights for 2025
-  private static final double  kHeightStowed         = 0.0;             // By definition - full down
-  private static final double  kHeightCoralStation   = 0.0;             // By definition - at coral station
+  private static final double  kHeightStowed           = 0.0;             // By definition - full down
+  private static final double  kHeightCoralStation     = 0.0;             // By definition - at coral station
 
-  private static final double  kHeightCoralL1        = 5.0;             // By definition - at L1 for scoring coral
-  private static final double  kHeightCoralL2        = 10.0;            // By definition - at L2 for scoring coral
-  private static final double  kHeightCoralL3        = 15.0;            // By definition - at L3 for scoring coral
-  private static final double  kHeightCoralL4        = 20.0;            // By definition - at L4 for scoring coral
+  private static final double  kHeightCoralL1          = 5.0;             // By definition - at L1 for scoring coral
+  private static final double  kHeightCoralL2          = 10.0;            // By definition - at L2 for scoring coral
+  private static final double  kHeightCoralL3          = 15.0;            // By definition - at L3 for scoring coral
+  private static final double  kHeightCoralL4          = 20.0;            // By definition - at L4 for scoring coral
 
-  private static final double  kHeightAlgaeL23       = 12.5;            // By definition - at L23 for taking algae
-  private static final double  kHeightAlgaeL34       = 17.5;            // By definition - at L34 for taking algae
-  private static final double  kHeightAlgaeNet       = 25.0;            // By definition - at scoring algae in net
-  private static final double  kHeightAlgaeProcessor = 0.0;             // By definition - at scoring algae in processor
+  private static final double  kHeightAlgaeL23         = 12.5;            // By definition - at L23 for taking algae
+  private static final double  kHeightAlgaeL34         = 17.5;            // By definition - at L34 for taking algae
+  private static final double  kHeightAlgaeNet         = 25.0;            // By definition - at scoring algae in net
+  private static final double  kHeightAlgaeProcessor   = 0.0;             // By definition - at scoring algae in processor
 
   /** Elevator manual move parameters */
   private enum JoystickMode
@@ -115,7 +115,7 @@ public class Elevator extends SubsystemBase
   // Simulation objects
   private final TalonFXSimState       m_motorSim          = m_leftMotor.getSimState( );
   private final ElevatorSim           m_elevSim           = new ElevatorSim(DCMotor.getKrakenX60Foc(2), kGearRatio,
-      kCarriageMassKg, kDrumRadiusMeters, kSimHeightMetersMin, kSimHeightMetersMax, false, 0.0);
+      kCarriageMassKg, kSprocketRadiusMeters, kSimHeightMetersMin, kSimHeightMetersMax, false, 0.0);
 
   // Mechanism2d
   private final Mechanism2d           m_elevatorMech      = new Mechanism2d(1.0, 1.0);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description (What changed)
<!--- Describe your changes in detail -->
Fix rollut ratio calculation for elevator sprocket (not drum) and update all references.

## Motivation and Context (Why needed)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Elevator movement is currently not accurate in height.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Compiles with no errors and no ***additional*** warnings
- [x] Simulates without crashes, errors or warnings
- [x] Simulates with the change under test successfully working
- [ ] Tested in the robot with no crashes, errors or warnings
- [x] I verified the log messages were as expected with no warnings in AdvantageScope

## Screenshots (optional: if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The auto-formatter was working correctly when submitted
- [x] I have updated any comments accordingly.
