### PR TITLE
Fix practice robot swerve wheel diameter to match worn colson wheels

### DIFF
--- a/Comp2025/src/main/java/frc/robot/generated/TunerConstants.java
+++ b/Comp2025/src/main/java/frc/robot/generated/TunerConstants.java
@@ -85,7 +85,7 @@ public class TunerConstants {
 
     private static final double kDriveGearRatio = Robot.isComp() ? 6.122448979591837 : 6.746031746031747;
     private static final double kSteerGearRatio = 21.428571428571427;
-    private static final Distance kWheelRadius = Inches.of(2);
+    private static final Distance kWheelRadius = Robot.isComp() ? Inches.of(2) : Inches.of(3.65/2);
 
     private static final boolean kInvertLeftSide = false;
     private static final boolean kInvertRightSide = true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description (What changed)
<!--- Describe your changes in detail -->
Added a check for the practice robot and set the wheel radius to the measured diameter divided by 2.

## Motivation and Context (Why needed)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows autonomous testing on practice robot to be accurate.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Compiles with no errors and no ***additional*** warnings
- [x] Simulates without crashes, errors or warnings
- [x] Simulates with the change under test successfully working
- [x] Tested in the robot with no crashes, errors or warnings
- [x] I verified the log messages were as expected with no warnings in AdvantageScope

## Screenshots (optional: if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The auto-formatter was working correctly when submitted
- [x] I have updated any comments accordingly.
