### PR TITLE
Fix auto in teleop cmd

### DIFF
--- a/Comp2025/src/main/java/frc/robot/RobotContainer.java
+++ b/Comp2025/src/main/java/frc/robot/RobotContainer.java
@@ -216,7 +216,13 @@ public class RobotContainer
     m_startChooser.addOption("START3", StartPose.START3);
     m_startChooser.onChange(this::updateStartChooserCallback);
 
-    SmartDashboard.putData("AutoChooserRun", new InstantCommand(( ) -> getAutonomousCommand( )));
+    SmartDashboard.putData("AutoChooserRun", new InstantCommand(( ) ->
+    {
+      if (m_autoCommand != null)
+      {
+        m_autoCommand.schedule( );
+      }
+    }));
 
     // Command tab
     // SmartDashboard.putData("PrepareToClimb", new PrepareToClimb(m_climber, m_feeder));

--- a/Comp2025/src/main/java/frc/robot/RobotContainer.java
+++ b/Comp2025/src/main/java/frc/robot/RobotContainer.java
@@ -218,7 +218,11 @@ public class RobotContainer
 
     SmartDashboard.putData("AutoChooserRun", new InstantCommand(( ) ->
     {
-      if (m_autoCommand != null)
+      if (m_autoCommand.isScheduled( ))
+      {
+        m_autoCommand.cancel( );
+      }
+      if ((m_autoCommand = getAutonomousCommand( )) != null)
       {
         m_autoCommand.schedule( );
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description (What changed)
<!--- Describe your changes in detail -->
Enable auto commands to run in teleop by cancelling any old command and reloading auto using getAutonomousCommand.

## Motivation and Context (Why needed)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need to support auto commands to test during teleop. This can still fail in rare occurrences.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Compiles with no errors and no ***additional*** warnings
- [x] Simulates without crashes, errors or warnings
- [x] Simulates with the change under test successfully working
- [ ] Tested in the robot with no crashes, errors or warnings
- [x] I verified the log messages were as expected with no warnings in AdvantageScope

## Screenshots (optional: if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The auto-formatter was working correctly when submitted
- [x] I have updated any comments accordingly.
