### PR TITLE
Tuning comp constants

### DIFF
--- a/Comp2025/src/main/java/frc/robot/RobotContainer.java
+++ b/Comp2025/src/main/java/frc/robot/RobotContainer.java
@@ -15,8 +15,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.xml.crypto.Data;
-
 import org.json.simple.parser.ParseException;
 
 import com.ctre.phoenix6.swerve.SwerveModule.DriveRequestType;
@@ -39,7 +37,6 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
-import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.DeferredCommand;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
@@ -325,7 +322,7 @@ public class RobotContainer
         ( ) ->
         {
           m_reefLevelPub.set(level);
-        }).withName(ELConsts.kReefLevelString);
+        }).withName(ELConsts.kReefLevelString).ignoringDisable(true);
   }
 
   /****************************************************************************
@@ -341,7 +338,7 @@ public class RobotContainer
         ( ) ->
         {
           m_reefOffsetPub.set(branch);
-        }).withName(VIConsts.kReefOffsetString);
+        }).withName(VIConsts.kReefOffsetString).ignoringDisable(true);
   }
 
   /****************************************************************************

--- a/Comp2025/src/main/java/frc/robot/RobotContainer.java
+++ b/Comp2025/src/main/java/frc/robot/RobotContainer.java
@@ -481,7 +481,6 @@ public class RobotContainer
               .withVelocityY(kMaxSpeed.times(-m_driverPad.getLeftX( )))                       // Drive left with negative X (left)
               .withRotationalRate(kMaxAngularRate.times(-m_driverPad.getRightX( )))           // Drive counterclockwise with negative X (left)
           )                                                                                   //
-              .ignoringDisable(true)                                      //
               .withName("CommandSwerveDrivetrain"));
     }
     else // When using simulation on MacOS X, XBox controllers need to be re-mapped due to an Apple bug
@@ -492,7 +491,6 @@ public class RobotContainer
               .withVelocityY(kMaxSpeed.times(-m_driverPad.getLeftX( )))                       // Drive left with negative X (left)
               .withRotationalRate(kMaxAngularRate.times(-m_driverPad.getLeftTriggerAxis( )))  // Drive counterclockwise with negative X (left)
           )                                                                                   //
-              .ignoringDisable(true)                                      //
               .withName("CommandSwerveDrivetrain"));
     }
 

--- a/Comp2025/src/main/java/frc/robot/RobotContainer.java
+++ b/Comp2025/src/main/java/frc/robot/RobotContainer.java
@@ -253,6 +253,8 @@ public class RobotContainer
         NetworkTableInstance.getDefault( ).getTable(Constants.kRobotString).getIntegerTopic(ELConsts.kReefLevelString).publish( );
     m_reefOffsetPub = NetworkTableInstance.getDefault( ).getTable(Constants.kRobotString)
         .getIntegerTopic(VIConsts.kReefOffsetString).publish( );
+    m_reefLevelPub.set(3);  // Default to level 3 during auto
+    m_reefOffsetPub.set(0); // Default to left branch
 
     // Build autonomous chooser objects on dashboard and fill the options
     SmartDashboard.putData("AutoMode", m_autoChooser);

--- a/Comp2025/src/main/java/frc/robot/commands/AcquireAlgae.java
+++ b/Comp2025/src/main/java/frc/robot/commands/AcquireAlgae.java
@@ -32,10 +32,10 @@ public class AcquireAlgae extends SequentialCommandGroup
 
     switch (level)
     {
-      default :
       case 1 : // Algae Level 23
       case 2 :
         return ReefLevel.ONE;
+      default :
       case 3 : // Algae Level 34
       case 4 :
         return ReefLevel.THREE;

--- a/Comp2025/src/main/java/frc/robot/commands/AcquireAlgae.java
+++ b/Comp2025/src/main/java/frc/robot/commands/AcquireAlgae.java
@@ -32,10 +32,10 @@ public class AcquireAlgae extends SequentialCommandGroup
 
     switch (level)
     {
+      default :
       case 1 : // Algae Level 23
       case 2 :
         return ReefLevel.ONE;
-      default :
       case 3 : // Algae Level 34
       case 4 :
         return ReefLevel.THREE;

--- a/Comp2025/src/main/java/frc/robot/commands/ScoreCoral.java
+++ b/Comp2025/src/main/java/frc/robot/commands/ScoreCoral.java
@@ -35,9 +35,9 @@ public class ScoreCoral extends SequentialCommandGroup
         return ReefLevel.ONE;
       case 2 : // Coral Level 2
         return ReefLevel.TWO;
+      default :
       case 3 : // Coral Level 3
         return ReefLevel.THREE;
-      default :
       case 4 : // Coral Level 4
         return ReefLevel.FOUR;
     }

--- a/Comp2025/src/main/java/frc/robot/commands/ScoreCoral.java
+++ b/Comp2025/src/main/java/frc/robot/commands/ScoreCoral.java
@@ -92,16 +92,16 @@ public class ScoreCoral extends SequentialCommandGroup
 
         new LogCommand(getName(), "Start coral rollers"),
         manipulator.getMoveToPositionCommand(ClawMode.CORALEXPEL, manipulator::getCurrentAngle), //level 4
-
+        
         new LogCommand(getName(), "Wait for coral to expel"),
-        new WaitCommand(0.25),
+        new WaitCommand(0.5),
         new WaitUntilCommand(manipulator::isCoralExpelled), // checks if coral is expelled 
       
         new LogCommand(getName(), "Stop coral rollers"), 
         manipulator.getMoveToPositionCommand(ClawMode.STOP, manipulator::getAngleSafeState), // Manipulator Safe State 
 
         new LogCommand(getName(), "Move Elevator to stowed height"),
-        elevator.getMoveToPositionCommand(elevator::getHeightStowed) // coral station height
+        elevator.getMoveToPositionCommand(elevator::getHeightCoralL1) // coral station height
         
         // @formatter:on
     );

--- a/Comp2025/src/main/java/frc/robot/commands/ScoreCoral.java
+++ b/Comp2025/src/main/java/frc/robot/commands/ScoreCoral.java
@@ -35,9 +35,9 @@ public class ScoreCoral extends SequentialCommandGroup
         return ReefLevel.ONE;
       case 2 : // Coral Level 2
         return ReefLevel.TWO;
-      default :
       case 3 : // Coral Level 3
         return ReefLevel.THREE;
+      default :
       case 4 : // Coral Level 4
         return ReefLevel.FOUR;
     }

--- a/Comp2025/src/main/java/frc/robot/lib/phoenix/CTREConfigs6.java
+++ b/Comp2025/src/main/java/frc/robot/lib/phoenix/CTREConfigs6.java
@@ -45,13 +45,13 @@ public final class CTREConfigs6
     // exConfig.ClosedLoopRamps.*
 
     // Current limit settings
-    elevatorConfig.CurrentLimits.SupplyCurrentLimit = 80.0;        // Amps
-    elevatorConfig.CurrentLimits.SupplyCurrentLowerLimit = 80.0;   // Amps
+    elevatorConfig.CurrentLimits.SupplyCurrentLimit = 40.0;        // Amps
+    elevatorConfig.CurrentLimits.SupplyCurrentLowerLimit = 40.0;   // Amps
     elevatorConfig.CurrentLimits.SupplyCurrentLowerTime = 0.001;   // Seconds
     elevatorConfig.CurrentLimits.SupplyCurrentLimitEnable = true;
 
-    elevatorConfig.CurrentLimits.StatorCurrentLimit = 800.0;        // Amps
-    elevatorConfig.CurrentLimits.StatorCurrentLimitEnable = false;
+    elevatorConfig.CurrentLimits.StatorCurrentLimit = 400.0;        // Amps
+    elevatorConfig.CurrentLimits.StatorCurrentLimitEnable = true;
 
     // Feedback settings
     // elevatorConfig.Feedback.*
@@ -177,12 +177,12 @@ public final class CTREConfigs6
     // wristRotaryConfig.ClosedLoopRamps.*                           // Seconds to ramp
 
     // Current limit settings
-    wristRotaryConfig.CurrentLimits.SupplyCurrentLimit = 30.0;       // Amps
-    wristRotaryConfig.CurrentLimits.SupplyCurrentLowerLimit = 30.0;  // Amps
+    wristRotaryConfig.CurrentLimits.SupplyCurrentLimit = 20.0;       // Amps
+    wristRotaryConfig.CurrentLimits.SupplyCurrentLowerLimit = 20.0;  // Amps
     wristRotaryConfig.CurrentLimits.SupplyCurrentLowerTime = 0.001;  // Seconds
     wristRotaryConfig.CurrentLimits.SupplyCurrentLimitEnable = true;
 
-    wristRotaryConfig.CurrentLimits.StatorCurrentLimit = 400.0;      // Amps
+    wristRotaryConfig.CurrentLimits.StatorCurrentLimit = 200.0;      // Amps
     wristRotaryConfig.CurrentLimits.StatorCurrentLimitEnable = true;
 
     // Feedback settings
@@ -195,9 +195,9 @@ public final class CTREConfigs6
     // wristRotaryConfig.HardwareLimitSwitch.*
 
     // Motion Magic settings - fused CANcoder affects all feedback constants by the gearRatio // TODO: wrist is temporarily slowed until we get it tuned
-    wristRotaryConfig.MotionMagic.MotionMagicCruiseVelocity = 62.83 / gearRatio;  // Rotations / second
-    wristRotaryConfig.MotionMagic.MotionMagicAcceleration = 241.7 / gearRatio;   // Rotations / second ^ 2
-    wristRotaryConfig.MotionMagic.MotionMagicJerk = 2417.0 / gearRatio;          // Rotations / second ^ 3
+    wristRotaryConfig.MotionMagic.MotionMagicCruiseVelocity = 62.83 / gearRatio * 0.75;  // Rotations / second
+    wristRotaryConfig.MotionMagic.MotionMagicAcceleration = 241.7 / gearRatio * 0.75;   // Rotations / second ^ 2
+    wristRotaryConfig.MotionMagic.MotionMagicJerk = 2417.0 / gearRatio * 0.75;          // Rotations / second ^ 3
 
     // Motor output settings
     wristRotaryConfig.MotorOutput.DutyCycleNeutralDeadband = 0.001;    // Percentage

--- a/Comp2025/src/main/java/frc/robot/lib/phoenix/CTREConfigs6.java
+++ b/Comp2025/src/main/java/frc/robot/lib/phoenix/CTREConfigs6.java
@@ -212,8 +212,8 @@ public final class CTREConfigs6
     //                                                                  kG = (0.40 + 0.25) / 2
     //                                                                  kS = (0.40 - 0.25) / 2
     wristRotaryConfig.Slot0.GravityType = GravityTypeValue.Arm_Cosine; // Feedforward: Mechanism is an arm and needs cosine
-    wristRotaryConfig.Slot0.kS = 0.0;                                  // Feedforward: Voltage or duty cylce to overcome static friction
-    wristRotaryConfig.Slot0.kG = 0.0;                                  // Feedforward: Voltage or duty cylce to overcome gravity (arbitrary feedforward)
+    wristRotaryConfig.Slot0.kS = -0.065;                                  // Feedforward: Voltage or duty cylce to overcome static friction
+    wristRotaryConfig.Slot0.kG = -0.235;                                  // Feedforward: Voltage or duty cylce to overcome gravity (arbitrary feedforward)
     wristRotaryConfig.Slot0.kV = 0.1241;                               // Feedforward: Voltage or duty cycle per requested RPS (velocity modes)
 
     wristRotaryConfig.Slot0.kP = 0.9 * gearRatio;                      // Feedback: Voltage or duty cycle per velocity unit (velocity modes)

--- a/Comp2025/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/Comp2025/src/main/java/frc/robot/subsystems/Elevator.java
@@ -76,15 +76,15 @@ public class Elevator extends SubsystemBase
 
   private static final double  kToleranceInches        = 0.5;             // PID tolerance in inches
   private static final double  kMMDebounceTime         = 0.060;           // Seconds to debounce a final position check
-  private static final double  kMMMoveTimeout          = 1.5;             // Seconds allowed for a Motion Magic movement
+  private static final double  kMMMoveTimeout          = 3.0;             // Seconds allowed for a Motion Magic movement
 
   // Elevator heights - Motion Magic config parameters                    // TODO: define desired elevator heights for 2025
   private static final double  kHeightStowed           = 0.0;             // By definition - full down
   private static final double  kHeightCoralStation     = 0.0;             // By definition - at coral station
 
   private static final double  kHeightCoralL1          = 3.0;             // By definition - at L1 for scoring coral
-  private static final double  kHeightCoralL2          = 7.5;             // By definition - at L2 for scoring coral
-  private static final double  kHeightCoralL3          = 15.0;            // By definition - at L3 for scoring coral
+  private static final double  kHeightCoralL2          = 8.0;             // By definition - at L2 for scoring coral
+  private static final double  kHeightCoralL3          = 16.0;            // By definition - at L3 for scoring coral
   private static final double  kHeightCoralL4          = 26.95;            // By definition - at L4 for scoring coral
 
   private static final double  kHeightAlgaeL23         = 12.5;            // By definition - at L23 for taking algae

--- a/Comp2025/src/main/java/frc/robot/subsystems/Manipulator.java
+++ b/Comp2025/src/main/java/frc/robot/subsystems/Manipulator.java
@@ -74,7 +74,7 @@ public class Manipulator extends SubsystemBase
   private static final DutyCycleOut kClawRollerStop      = new DutyCycleOut(0.0).withIgnoreHardwareLimits(true);
 
   private static final DutyCycleOut kCoralSpeedAcquire   = new DutyCycleOut(-0.5).withIgnoreHardwareLimits(false);
-  private static final DutyCycleOut kCoralSpeedExpel     = new DutyCycleOut(-0.25).withIgnoreHardwareLimits(true);
+  private static final DutyCycleOut kCoralSpeedExpel     = new DutyCycleOut(-0.15).withIgnoreHardwareLimits(true);
 
   private static final DutyCycleOut kAlgaeSpeedAcquire   = new DutyCycleOut(0.5).withIgnoreHardwareLimits(true);
   private static final DutyCycleOut kAlgaeSpeedExpel     = new DutyCycleOut(-0.4).withIgnoreHardwareLimits(true);
@@ -98,7 +98,7 @@ public class Manipulator extends SubsystemBase
 
   private static final double         kToleranceDegrees         = 3.0;      // PID tolerance in degrees
   private static final double         kMMDebounceTime           = 0.060;    // Seconds to debounce a final angle check
-  private static final double         kMMMoveTimeout            = 1.0;      // Seconds allowed for a Motion Magic movement
+  private static final double         kMMMoveTimeout            = 2.0;      // Seconds allowed for a Motion Magic movement
 
   // Wrist rotary angles - Motion Magic move parameters - TODO: Update for 2025 Reefscape needs
   //    Measured hardstops and pre-defined positions:
@@ -108,13 +108,13 @@ public class Manipulator extends SubsystemBase
   private static final double         kWristAngleMin            = -119.0; //TODO: Complete all with Correct Angles 
   private static final double         kWristAngleMax            = 52.0;
 
-  private static final double         kWristAngleSafeState      = -95.0;
+  private static final double         kWristAngleSafeState      = -92.0;
 
   private static final double         kWristAngleCoralStation   = -119.0;
-  private static final double         kWristAngleCoralL1        = -95.0;//-90
-  private static final double         kWristAngleCoralL2        = -75.0;//-75
-  private static final double         kWristAngleCoralL3        = -75.0;//75
-  private static final double         kWristAngleCoralL4        = -85.0;//-45
+  private static final double         kWristAngleCoralL1        = -95.0;
+  private static final double         kWristAngleCoralL2        = -95.0;
+  private static final double         kWristAngleCoralL3        = -95.0;
+  private static final double         kWristAngleCoralL4        = -85.0;
 
   private static final double         kWristAngleAlgae23        = 51.5;
   private static final double         kWristAngleAlgae34        = 51.5;


### PR DESCRIPTION
Comp Robot Constants adjusted based on the reef. 

## Description (What changed)
Config constants for the wrist rotary have been tuned. The comp robot height and manipulator angles have been adjusted based on the reef, with the robot about 1 coral away from the reef wall. PID constants have been slowed down for testing purposes. 

## Motivation and Context (Why needed)
This change allowed the PID movements of the robot to be smoother, and for the robot to score on level 2 and 3 of the reef, assuming the robot can align one coral away from the reef. Robot PID constants have been slowed down to assist testing. 

## How has this been tested?
The code was tested in the robot. This change will affect acquiring and scoring for the robot.
- [x] Compiles with no errors and no ***additional*** warnings
- [ ] Simulates without crashes, errors or warnings
- [ ] Simulates with the change under test successfully working
- [x] Tested in the robot with no crashes, errors or warnings
- [x] I verified the log messages were as expected with no warnings in AdvantageScope

## Screenshots (optional: if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The auto-formatter was working correctly when submitted
- [x] I have updated any comments accordingly.
