### PR TITLE
Tuning reef scoring

### DIFF
--- a/Comp2025/src/main/java/frc/robot/commands/ScoreAlgae.java
+++ b/Comp2025/src/main/java/frc/robot/commands/ScoreAlgae.java
@@ -101,7 +101,7 @@ public class ScoreAlgae extends SequentialCommandGroup
         manipulator.getMoveToPositionCommand(ClawMode.STOP, manipulator::getAngleSafeState), // Manipulator Safe State
         
         new LogCommand(getName(), "Move Elevator to stowed height"),
-        elevator.getMoveToPositionCommand(elevator::getHeightStowed) // stowed
+        elevator.getMoveToPositionCommand(elevator::getHeightCoralStation) // stowed
         
         // @formatter:on
     );

--- a/Comp2025/src/main/java/frc/robot/commands/ScoreAlgae.java
+++ b/Comp2025/src/main/java/frc/robot/commands/ScoreAlgae.java
@@ -101,7 +101,7 @@ public class ScoreAlgae extends SequentialCommandGroup
         manipulator.getMoveToPositionCommand(ClawMode.STOP, manipulator::getAngleSafeState), // Manipulator Safe State
         
         new LogCommand(getName(), "Move Elevator to stowed height"),
-        elevator.getMoveToPositionCommand(elevator::getHeightCoralStation) // stowed
+        elevator.getMoveToPositionCommand(elevator::getHeightStowed) // stowed
         
         // @formatter:on
     );

--- a/Comp2025/src/main/java/frc/robot/commands/ScoreCoral.java
+++ b/Comp2025/src/main/java/frc/robot/commands/ScoreCoral.java
@@ -101,7 +101,7 @@ public class ScoreCoral extends SequentialCommandGroup
         manipulator.getMoveToPositionCommand(ClawMode.STOP, manipulator::getAngleSafeState), // Manipulator Safe State 
 
         new LogCommand(getName(), "Move Elevator to stowed height"),
-        elevator.getMoveToPositionCommand(elevator::getHeightCoralL1) // coral station height
+        elevator.getMoveToPositionCommand(elevator::getHeightCoralL2) // coral station height
         
         // @formatter:on
     );

--- a/Comp2025/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/Comp2025/src/main/java/frc/robot/subsystems/Elevator.java
@@ -83,9 +83,9 @@ public class Elevator extends SubsystemBase
   private static final double  kHeightCoralStation     = 0.0;             // By definition - at coral station
 
   private static final double  kHeightCoralL1          = 3.0;             // By definition - at L1 for scoring coral
-  private static final double  kHeightCoralL2          = 8.0;             // By definition - at L2 for scoring coral
-  private static final double  kHeightCoralL3          = 16.0;            // By definition - at L3 for scoring coral
-  private static final double  kHeightCoralL4          = 26.95;            // By definition - at L4 for scoring coral
+  private static final double  kHeightCoralL2          = 6.25;            // By definition - at L2 for scoring coral
+  private static final double  kHeightCoralL3          = 14.25;           // By definition - at L3 for scoring coral
+  private static final double  kHeightCoralL4          = 26.95;           // By definition - at L4 for scoring coral
 
   private static final double  kHeightAlgaeL23         = 12.5;            // By definition - at L23 for taking algae
   private static final double  kHeightAlgaeL34         = 20.5;            // By definition - at L34 for taking algae

--- a/Comp2025/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/Comp2025/src/main/java/frc/robot/subsystems/Elevator.java
@@ -83,8 +83,8 @@ public class Elevator extends SubsystemBase
   private static final double  kHeightCoralStation     = 0.0;             // By definition - at coral station
 
   private static final double  kHeightCoralL1          = 3.0;             // By definition - at L1 for scoring coral
-  private static final double  kHeightCoralL2          = 6.5;            // By definition - at L2 for scoring coral
-  private static final double  kHeightCoralL3          = 14.5;           // By definition - at L3 for scoring coral
+  private static final double  kHeightCoralL2          = 6.5;             // By definition - at L2 for scoring coral
+  private static final double  kHeightCoralL3          = 14.5;            // By definition - at L3 for scoring coral
   private static final double  kHeightCoralL4          = 26.95;           // By definition - at L4 for scoring coral
 
   private static final double  kHeightAlgaeL23         = 12.5;            // By definition - at L23 for taking algae

--- a/Comp2025/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/Comp2025/src/main/java/frc/robot/subsystems/Elevator.java
@@ -83,8 +83,8 @@ public class Elevator extends SubsystemBase
   private static final double  kHeightCoralStation     = 0.0;             // By definition - at coral station
 
   private static final double  kHeightCoralL1          = 3.0;             // By definition - at L1 for scoring coral
-  private static final double  kHeightCoralL2          = 6.25;            // By definition - at L2 for scoring coral
-  private static final double  kHeightCoralL3          = 14.25;           // By definition - at L3 for scoring coral
+  private static final double  kHeightCoralL2          = 6.5;            // By definition - at L2 for scoring coral
+  private static final double  kHeightCoralL3          = 14.5;           // By definition - at L3 for scoring coral
   private static final double  kHeightCoralL4          = 26.95;           // By definition - at L4 for scoring coral
 
   private static final double  kHeightAlgaeL23         = 12.5;            // By definition - at L23 for taking algae


### PR DESCRIPTION
Scoring Coral for Level 2 and 3 has been adjusted to new robot positioning.

## Description (What changed)
Elevator heights for Branch level 2 and 3 have been adjusted for the robot against the reef. Ending height for the score coral has been adjusted. 

## Motivation and Context (Why needed)
The change was required to score on level 2 and 3 with the new robot positioning against the reef. 

## How has this been tested?
The code has been tested in the comp robot. It has been tested against the reef. 
- [x] Compiles with no errors and no ***additional*** warnings
- [ ] Simulates without crashes, errors or warnings
- [ ] Simulates with the change under test successfully working
- [x] Tested in the robot with no crashes, errors or warnings
- [x] I verified the log messages were as expected with no warnings in AdvantageScope

## Screenshots (optional: if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The auto-formatter was working correctly when submitted
- [x] I have updated any comments accordingly.
