### PR TITLE
Added parallel command groups for acquire & drive

### DIFF
--- a/Comp2025/src/main/java/frc/robot/autos/AutoPreloadCoral.java
+++ b/Comp2025/src/main/java/frc/robot/autos/AutoPreloadCoral.java
@@ -7,6 +7,7 @@ import java.util.function.Supplier;
 import com.pathplanner.lib.path.PathPlannerPath;
 
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.robot.commands.AcquireCoral;
 import frc.robot.commands.LogCommand;
@@ -54,8 +55,10 @@ public class AutoPreloadCoral extends SequentialCommandGroup
         new ScoreCoral(elevator, manipulator, led, hid),
 
         new LogCommand(getName(), "Drive to coral station and acquire second coral"),
-        drivetrain.getPathCommand(ppPaths.get(1)),
-        new AcquireCoral(elevator, manipulator, led, hid),
+        new ParallelCommandGroup(
+          drivetrain.getPathCommand(ppPaths.get(1)),
+          new AcquireCoral(elevator, manipulator, led, hid)
+        ), 
 
         new LogCommand(getName(), "Drive to branch and score second coral"),
         drivetrain.getPathCommand(ppPaths.get(2)),

--- a/Comp2025/src/main/java/frc/robot/autos/AutoPreloadCoral2.java
+++ b/Comp2025/src/main/java/frc/robot/autos/AutoPreloadCoral2.java
@@ -67,7 +67,7 @@ public class AutoPreloadCoral2 extends SequentialCommandGroup
         drivetrain.getPathCommand(ppPaths.get(2)),
         new ScoreCoral(elevator, manipulator, led, hid),
 
-        new LogCommand(getName(), "Drive to coral station and acquire second coral"),
+        new LogCommand(getName(), "Drive to coral station and acquire third coral"),
         new ParallelCommandGroup(
           drivetrain.getPathCommand(ppPaths.get(3)),
           new AcquireCoral(elevator, manipulator, led, hid)

--- a/Comp2025/src/main/java/frc/robot/autos/AutoPreloadCoral2.java
+++ b/Comp2025/src/main/java/frc/robot/autos/AutoPreloadCoral2.java
@@ -6,6 +6,7 @@ import java.util.function.Supplier;
 import com.pathplanner.lib.path.PathPlannerPath;
 
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.robot.commands.AcquireCoral;
 import frc.robot.commands.LogCommand;
@@ -57,16 +58,20 @@ public class AutoPreloadCoral2 extends SequentialCommandGroup
         new ScoreCoral(elevator, manipulator, led, hid),
 
         new LogCommand(getName(), "Drive to coral station and acquire second coral"),
-        drivetrain.getPathCommand(ppPaths.get(1)),
-        new AcquireCoral(elevator, manipulator, led, hid),
+        new ParallelCommandGroup(
+          drivetrain.getPathCommand(ppPaths.get(1)),
+          new AcquireCoral(elevator, manipulator, led, hid)
+        ), 
 
         new LogCommand(getName(), "Drive to branch and score second coral"),
         drivetrain.getPathCommand(ppPaths.get(2)),
         new ScoreCoral(elevator, manipulator, led, hid),
 
-        new LogCommand(getName(), "Drive to coral station and acquire third coral"),
-        drivetrain.getPathCommand(ppPaths.get(3)),
-        new AcquireCoral(elevator, manipulator, led, hid),
+        new LogCommand(getName(), "Drive to coral station and acquire second coral"),
+        new ParallelCommandGroup(
+          drivetrain.getPathCommand(ppPaths.get(3)),
+          new AcquireCoral(elevator, manipulator, led, hid)
+        ), 
 
         new LogCommand(getName(), "Drive to branch and score third coral"),   
         drivetrain.getPathCommand(ppPaths.get(4)),

--- a/Comp2025/src/main/java/frc/robot/autos/AutoPreloadCoral3.java
+++ b/Comp2025/src/main/java/frc/robot/autos/AutoPreloadCoral3.java
@@ -70,11 +70,11 @@ public class AutoPreloadCoral3 extends SequentialCommandGroup
           new AcquireCoral(elevator, manipulator, led, hid)
         ), 
 
-        new LogCommand(getName(), "Drive to branch and score fourth coral"),   
+        new LogCommand(getName(), "Drive to branch and score third coral"),   
         drivetrain.getPathCommand(ppPaths.get(4)),
         new ScoreCoral(elevator, manipulator, led, hid),
 
-        new LogCommand(getName(), "Drive to coral station and acquire second coral"),
+        new LogCommand(getName(), "Drive to coral station and acquire fourth coral"),
         new ParallelCommandGroup(
           drivetrain.getPathCommand(ppPaths.get(5)),
           new AcquireCoral(elevator, manipulator, led, hid)

--- a/Comp2025/src/main/java/frc/robot/autos/AutoPreloadCoral3.java
+++ b/Comp2025/src/main/java/frc/robot/autos/AutoPreloadCoral3.java
@@ -64,13 +64,13 @@ public class AutoPreloadCoral3 extends SequentialCommandGroup
         drivetrain.getPathCommand(ppPaths.get(2)),
         new ScoreCoral(elevator, manipulator, led, hid),
 
-        new LogCommand(getName(), "Drive to coral station and acquire second coral"),
+        new LogCommand(getName(), "Drive to coral station and acquire third coral"),
         new ParallelCommandGroup(
           drivetrain.getPathCommand(ppPaths.get(3)),
           new AcquireCoral(elevator, manipulator, led, hid)
         ), 
 
-        new LogCommand(getName(), "Drive to branch and score third coral"),   
+        new LogCommand(getName(), "Drive to branch and score fourth coral"),   
         drivetrain.getPathCommand(ppPaths.get(4)),
         new ScoreCoral(elevator, manipulator, led, hid),
 

--- a/Comp2025/src/main/java/frc/robot/autos/AutoPreloadCoral3.java
+++ b/Comp2025/src/main/java/frc/robot/autos/AutoPreloadCoral3.java
@@ -6,6 +6,7 @@ import java.util.function.Supplier;
 import com.pathplanner.lib.path.PathPlannerPath;
 
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.robot.commands.AcquireCoral;
 import frc.robot.commands.LogCommand;
@@ -54,24 +55,30 @@ public class AutoPreloadCoral3 extends SequentialCommandGroup
         new ScoreCoral(elevator, manipulator, led, hid),
 
         new LogCommand(getName(), "Drive to coral station and acquire second coral"),
-        drivetrain.getPathCommand(ppPaths.get(1)),
-        new AcquireCoral(elevator, manipulator, led, hid),
+        new ParallelCommandGroup(
+          drivetrain.getPathCommand(ppPaths.get(1)),
+          new AcquireCoral(elevator, manipulator, led, hid)
+        ), 
 
         new LogCommand(getName(), "Drive to branch and score second coral"),
         drivetrain.getPathCommand(ppPaths.get(2)),
         new ScoreCoral(elevator, manipulator, led, hid),
 
-        new LogCommand(getName(), "Drive to coral station and acquire third coral"),
-        drivetrain.getPathCommand(ppPaths.get(3)),
-        new AcquireCoral(elevator, manipulator, led, hid),
+        new LogCommand(getName(), "Drive to coral station and acquire second coral"),
+        new ParallelCommandGroup(
+          drivetrain.getPathCommand(ppPaths.get(3)),
+          new AcquireCoral(elevator, manipulator, led, hid)
+        ), 
 
         new LogCommand(getName(), "Drive to branch and score third coral"),   
         drivetrain.getPathCommand(ppPaths.get(4)),
         new ScoreCoral(elevator, manipulator, led, hid),
 
-        new LogCommand(getName(), "Drive coral station and acquire fourth coral"),
-        drivetrain.getPathCommand(ppPaths.get(5)),
-        new AcquireCoral(elevator, manipulator, led, hid),
+        new LogCommand(getName(), "Drive to coral station and acquire second coral"),
+        new ParallelCommandGroup(
+          drivetrain.getPathCommand(ppPaths.get(5)),
+          new AcquireCoral(elevator, manipulator, led, hid)
+        ), 
 
         new LogCommand(getName(), "Drive to branch and score fourth coral"), 
         drivetrain.getPathCommand(ppPaths.get(6)),


### PR DESCRIPTION
Added parallel command groups for acquire & drive

## Description (What changed)
Added parallel command groups for acquire & drive

## Motivation and Context (Why needed)
More efficient when acquiring coral during autos

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Compiles with no errors and no ***additional*** warnings
- [ ] Simulates without crashes, errors or warnings
- [ ] Simulates with the change under test successfully working
- [x] Tested in the robot with no crashes, errors or warnings
- [x] I verified the log messages were as expected with no warnings in AdvantageScope

## Screenshots (optional: if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The auto-formatter was working correctly when submitted
- [x] I have updated any comments accordingly.
