### PR TITLE
Add coral score delay

### DIFF
--- a/Comp2025/src/main/deploy/elastic-layout.json
+++ b/Comp2025/src/main/deploy/elastic-layout.json
@@ -30,9 +30,9 @@
           {
             "title": "Alerts",
             "x": 1024.0,
-            "y": 0.0,
+            "y": 256.0,
             "width": 256.0,
-            "height": 384.0,
+            "height": 256.0,
             "type": "Alerts",
             "properties": {
               "topic": "/SmartDashboard/Alerts",
@@ -66,19 +66,6 @@
             }
           },
           {
-            "title": "AutoChooserRun",
-            "x": 768.0,
-            "y": 384.0,
-            "width": 256.0,
-            "height": 128.0,
-            "type": "Command",
-            "properties": {
-              "topic": "/SmartDashboard/AutoChooserRun",
-              "period": 0.06,
-              "show_type": true
-            }
-          },
-          {
             "title": "AutoDelay",
             "x": 768.0,
             "y": 256.0,
@@ -94,8 +81,8 @@
           },
           {
             "title": "MatchTime",
-            "x": 0.0,
-            "y": 384.0,
+            "x": 1024.0,
+            "y": 0.0,
             "width": 256.0,
             "height": 128.0,
             "type": "Match Time",
@@ -110,8 +97,8 @@
           },
           {
             "title": "ReefLevel",
-            "x": 384.0,
-            "y": 384.0,
+            "x": 1024.0,
+            "y": 128.0,
             "width": 128.0,
             "height": 128.0,
             "type": "Large Text Display",
@@ -123,8 +110,8 @@
           },
           {
             "title": "ReefOffset",
-            "x": 512.0,
-            "y": 384.0,
+            "x": 1152.0,
+            "y": 128.0,
             "width": 128.0,
             "height": 128.0,
             "type": "Large Text Display",
@@ -231,8 +218,8 @@
         "containers": [
           {
             "title": "ElCalibrate",
-            "x": 768.0,
-            "y": 384.0,
+            "x": 256.0,
+            "y": 256.0,
             "width": 256.0,
             "height": 128.0,
             "type": "Command",
@@ -245,7 +232,7 @@
           {
             "title": "ElRunAlgae23",
             "x": 768.0,
-            "y": 0.0,
+            "y": 128.0,
             "width": 256.0,
             "height": 128.0,
             "type": "Command",
@@ -258,7 +245,7 @@
           {
             "title": "ElRunAlgae34",
             "x": 768.0,
-            "y": 128.0,
+            "y": 256.0,
             "width": 256.0,
             "height": 128.0,
             "type": "Command",
@@ -309,21 +296,8 @@
           },
           {
             "title": "ElRunCoralStation",
-            "x": 512.0,
-            "y": 384.0,
-            "width": 256.0,
-            "height": 128.0,
-            "type": "Command",
-            "properties": {
-              "topic": "/SmartDashboard/ElRunCoralStation",
-              "period": 0.06,
-              "show_type": true
-            }
-          },
-          {
-            "title": "ElRunCoralStation",
             "x": 256.0,
-            "y": 0.0,
+            "y": 128.0,
             "width": 256.0,
             "height": 128.0,
             "type": "Command",
@@ -335,8 +309,8 @@
           },
           {
             "title": "ElRunNet",
-            "x": 256.0,
-            "y": 384.0,
+            "x": 1024.0,
+            "y": 128.0,
             "width": 256.0,
             "height": 128.0,
             "type": "Command",
@@ -348,8 +322,8 @@
           },
           {
             "title": "ElRunProcessor",
-            "x": 256.0,
-            "y": 256.0,
+            "x": 1024.0,
+            "y": 0.0,
             "width": 256.0,
             "height": 128.0,
             "type": "Command",
@@ -362,12 +336,25 @@
           {
             "title": "ElRunStowed",
             "x": 256.0,
-            "y": 128.0,
+            "y": 0.0,
             "width": 256.0,
             "height": 128.0,
             "type": "Command",
             "properties": {
               "topic": "/SmartDashboard/ElRunStowed",
+              "period": 0.06,
+              "show_type": true
+            }
+          },
+          {
+            "title": "ElRunCoralL4",
+            "x": 768.0,
+            "y": 0.0,
+            "width": 256.0,
+            "height": 128.0,
+            "type": "Command",
+            "properties": {
+              "topic": "/SmartDashboard/ElRunCoralL4",
               "period": 0.06,
               "show_type": true
             }
@@ -522,8 +509,8 @@
           },
           {
             "title": "MNWristCoralL4",
-            "x": 512.0,
-            "y": 384.0,
+            "x": 768.0,
+            "y": 0.0,
             "width": 256.0,
             "height": 128.0,
             "type": "Command",
@@ -548,8 +535,8 @@
           },
           {
             "title": "MNWristAlgaeNet",
-            "x": 256.0,
-            "y": 256.0,
+            "x": 1024.0,
+            "y": 128.0,
             "width": 256.0,
             "height": 128.0,
             "type": "Command",
@@ -561,8 +548,8 @@
           },
           {
             "title": "MNWristAlgaeProcessor",
-            "x": 256.0,
-            "y": 384.0,
+            "x": 1024.0,
+            "y": 0.0,
             "width": 256.0,
             "height": 128.0,
             "type": "Command",
@@ -581,6 +568,32 @@
             "type": "Command",
             "properties": {
               "topic": "/SmartDashboard/MNWristCoralStation",
+              "period": 0.06,
+              "show_type": true
+            }
+          },
+          {
+            "title": "MNWristAlgaeL23",
+            "x": 768.0,
+            "y": 128.0,
+            "width": 256.0,
+            "height": 128.0,
+            "type": "Command",
+            "properties": {
+              "topic": "/SmartDashboard/MNWristAlgaeL23",
+              "period": 0.06,
+              "show_type": true
+            }
+          },
+          {
+            "title": "MNWristAlgaeL34",
+            "x": 768.0,
+            "y": 256.0,
+            "width": 256.0,
+            "height": 128.0,
+            "type": "Command",
+            "properties": {
+              "topic": "/SmartDashboard/MNWristAlgaeL34",
               "period": 0.06,
               "show_type": true
             }
@@ -735,8 +748,8 @@
           },
           {
             "title": "MNAlgaeMaintain",
-            "x": 768.0,
-            "y": 384.0,
+            "x": 256.0,
+            "y": 256.0,
             "width": 256.0,
             "height": 128.0,
             "type": "Command",
@@ -748,8 +761,8 @@
           },
           {
             "title": "MNAlgaeProcessor",
-            "x": 256.0,
-            "y": 256.0,
+            "x": 1024.0,
+            "y": 0.0,
             "width": 256.0,
             "height": 128.0,
             "type": "Command",
@@ -761,8 +774,8 @@
           },
           {
             "title": "MNAlgaeShoot",
-            "x": 256.0,
-            "y": 384.0,
+            "x": 1024.0,
+            "y": 128.0,
             "width": 256.0,
             "height": 128.0,
             "type": "Command",
@@ -873,7 +886,7 @@
           },
           {
             "title": "AcquireAlgae",
-            "x": 384.0,
+            "x": 256.0,
             "y": 0.0,
             "width": 256.0,
             "height": 128.0,
@@ -886,7 +899,7 @@
           },
           {
             "title": "AcquireCoral",
-            "x": 384.0,
+            "x": 256.0,
             "y": 128.0,
             "width": 256.0,
             "height": 128.0,
@@ -899,7 +912,7 @@
           },
           {
             "title": "ScoreAlgae",
-            "x": 640.0,
+            "x": 512.0,
             "y": 0.0,
             "width": 256.0,
             "height": 128.0,
@@ -912,7 +925,7 @@
           },
           {
             "title": "ScoreCoral",
-            "x": 640.0,
+            "x": 512.0,
             "y": 128.0,
             "width": 256.0,
             "height": 128.0,
@@ -925,13 +938,26 @@
           },
           {
             "title": "DriveToPoseCommand",
-            "x": 896.0,
+            "x": 768.0,
             "y": 0.0,
             "width": 256.0,
             "height": 128.0,
             "type": "Command",
             "properties": {
               "topic": "/SmartDashboard/DriveToPoseCommand",
+              "period": 0.06,
+              "show_type": true
+            }
+          },
+          {
+            "title": "AutoChooserRun",
+            "x": 768.0,
+            "y": 128.0,
+            "width": 256.0,
+            "height": 128.0,
+            "type": "Command",
+            "properties": {
+              "topic": "/SmartDashboard/AutoChooserRun",
               "period": 0.06,
               "show_type": true
             }

--- a/Comp2025/src/main/java/frc/robot/RobotContainer.java
+++ b/Comp2025/src/main/java/frc/robot/RobotContainer.java
@@ -253,7 +253,7 @@ public class RobotContainer
         NetworkTableInstance.getDefault( ).getTable(Constants.kRobotString).getIntegerTopic(ELConsts.kReefLevelString).publish( );
     m_reefOffsetPub = NetworkTableInstance.getDefault( ).getTable(Constants.kRobotString)
         .getIntegerTopic(VIConsts.kReefOffsetString).publish( );
-    m_reefLevelPub.set(3);  // Default to level 3 during auto TODO: make 4 the default!
+    m_reefLevelPub.set(4);  // Default to level 4 during auto
     m_reefOffsetPub.set(0); // Default to left branch
 
     // Build autonomous chooser objects on dashboard and fill the options
@@ -627,7 +627,7 @@ public class RobotContainer
 
   public Command getReefLevelCommand( ) // Command supplier to set default reef level
   {
-    return getReefLevelSelectCommand(3);
+    return getReefLevelSelectCommand(4);
   }
 
   /****************************************************************************

--- a/Comp2025/src/main/java/frc/robot/commands/ScoreCoral.java
+++ b/Comp2025/src/main/java/frc/robot/commands/ScoreCoral.java
@@ -94,8 +94,8 @@ public class ScoreCoral extends SequentialCommandGroup
         manipulator.getMoveToPositionCommand(ClawMode.CORALEXPEL, manipulator::getCurrentAngle),
         
         new LogCommand(getName(), "Wait for coral to expel"),
-        new WaitCommand(0.5),                                   // TODO: speed up?
         new WaitUntilCommand(manipulator::isCoralExpelled),
+        new WaitCommand(0.2),
       
         new LogCommand(getName(), "Stop coral rollers"), 
         manipulator.getMoveToPositionCommand(ClawMode.STOP, manipulator::getAngleSafeState), 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description (What changed)
<!--- Describe your changes in detail -->
Change command delay after coral is detected as expelled, since sensor triggers before the coral leaves the ejector. Also changed the default coral scoring level to L4 and updated the elastic dashboard.

## Motivation and Context (Why needed)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ejector was getting hung when scoring L4, because the delay was in the wrong place. Also, we now support L4 scoring in auto.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Compiles with no errors and no ***additional*** warnings
- [x] Simulates without crashes, errors or warnings
- [x] Simulates with the change under test successfully working
- [ ] Tested in the robot with no crashes, errors or warnings
- [x] I verified the log messages were as expected with no warnings in AdvantageScope

## Screenshots (optional: if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The auto-formatter was working correctly when submitted
- [x] I have updated any comments accordingly.
