### PR TITLE
Adjust snap movement and algae acquiring

### DIFF
--- a/Comp2025/src/main/java/frc/robot/RobotContainer.java
+++ b/Comp2025/src/main/java/frc/robot/RobotContainer.java
@@ -87,7 +87,7 @@ public class RobotContainer
   private static final LinearVelocity                 kMaxSpeed       = TunerConstants.kSpeedAt12Volts;     // Maximum top speed
   private static final AngularVelocity                kMaxAngularRate = RadiansPerSecond.of(2.0 * Math.PI); // Max 1.5 rot per second
   private static final double                         kSlowSwerve     = 0.30;                               // Throttle max swerve speeds for finer control
-  private static final double                         kHeadingKp      = 10.0;
+  private static final double                         kHeadingKp      = 6.0;
   private static final double                         kHeadingKi      = 0.0;
   private static final double                         kHeadingKd      = 0.0;
 

--- a/Comp2025/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/Comp2025/src/main/java/frc/robot/subsystems/Elevator.java
@@ -87,8 +87,8 @@ public class Elevator extends SubsystemBase
   private static final double  kHeightCoralL3          = 15.5;            // By definition - at L3 for scoring coral
   private static final double  kHeightCoralL4          = 27.95;           // By definition - at L4 for scoring coral
 
-  private static final double  kHeightAlgaeL23         = 12.5;            // By definition - at L23 for taking algae
-  private static final double  kHeightAlgaeL34         = 20.5;            // By definition - at L34 for taking algae
+  private static final double  kHeightAlgaeL23         = 11.0;            // By definition - at L23 for taking algae
+  private static final double  kHeightAlgaeL34         = 19.5;            // By definition - at L34 for taking algae
   private static final double  kHeightAlgaeNet         = 30.75;           // By definition - at scoring algae in net
   private static final double  kHeightAlgaeProcessor   = 4.0;             // By definition - at scoring algae in processor
 

--- a/Comp2025/src/main/java/frc/robot/subsystems/Manipulator.java
+++ b/Comp2025/src/main/java/frc/robot/subsystems/Manipulator.java
@@ -116,9 +116,9 @@ public class Manipulator extends SubsystemBase
   private static final double         kWristAngleCoralL3        = -100.0;
   private static final double         kWristAngleCoralL4        = -89.5;
 
-  private static final double         kWristAngleAlgae23        = 48.0;
-  private static final double         kWristAngleAlgae34        = 48.0;
-  private static final double         kWristAngleAlgaeProcessor = 48.0;
+  private static final double         kWristAngleAlgae23        = 29.0;
+  private static final double         kWristAngleAlgae34        = 29.0;
+  private static final double         kWristAngleAlgaeProcessor = 29.0;
   private static final double         kWristAngleAlgaeNet       = -10.0;
 
   // Device objects


### PR DESCRIPTION
Snap movement for aligning has been adjusted. Movements for acquiring algae have been adjusted. 

## Description (What changed)
Speed and constants for the snap movement had been adjusted. Algae Acquiring height and angle on reef adjusted for new manipulator.

## Motivation and Context (Why needed)
This change is required to acquire algae off of the reef, on level 23 and 34. Snap movements are being fixed.

## How has this been tested?
Algae can now be acquired off of the reef. Snap movements are still being adjusted to be more efficient and work better. 
- [x] Compiles with no errors and no ***additional*** warnings
- [ ] Simulates without crashes, errors or warnings
- [ ] Simulates with the change under test successfully working
- [x] Tested in the robot with no crashes, errors or warnings
- [x] I verified the log messages were as expected with no warnings in AdvantageScope

## Screenshots (optional: if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The auto-formatter was working correctly when submitted
- [x] I have updated any comments accordingly.
