### PR TITLE
Remove PID loop for algae holding

### DIFF
--- a/Comp2025/src/main/java/frc/robot/subsystems/Manipulator.java
+++ b/Comp2025/src/main/java/frc/robot/subsystems/Manipulator.java
@@ -581,15 +581,15 @@ public class Manipulator extends SubsystemBase
     }
     else
     {
-      if (mode == ClawMode.ALGAEHOLD)
-      {
-        double rotations = m_clawMotor.getPosition( ).getValueAsDouble( );
-        Slot0Configs slot0Configs = new Slot0Configs( ).withKP(25);
-        m_clawMotor.getConfigurator( ).apply(slot0Configs);
-        PositionDutyCycle positionDutyCycle = new PositionDutyCycle(rotations).withSlot(0).withEnableFOC(true);
-        m_clawMotor.setControl(positionDutyCycle);
-      }
-      else
+      // if (mode == ClawMode.ALGAEHOLD)
+      // {
+      //   double rotations = m_clawMotor.getPosition( ).getValueAsDouble( );
+      //   Slot0Configs slot0Configs = new Slot0Configs( ).withKP(25);
+      //   m_clawMotor.getConfigurator( ).apply(slot0Configs);
+      //   PositionDutyCycle positionDutyCycle = new PositionDutyCycle(rotations).withSlot(0).withEnableFOC(true);
+      //   m_clawMotor.setControl(positionDutyCycle);
+      // }
+      // else
       {
         switch (mode)
         {


### PR DESCRIPTION
Remove PID loop for Algae Hold state

## Description (What changed)
PID loop in manipulator removed. 

## Motivation and Context (Why needed)
This change was removed. Further testing needed in the future to implement it. 

## How has this been tested?
Code has been simulated. Algae acquired as expected. 
- [x] Compiles with no errors and no ***additional*** warnings
- [x] Simulates without crashes, errors or warnings
- [x] Simulates with the change under test successfully working
- [ ] Tested in the robot with no crashes, errors or warnings
- [ ] I verified the log messages were as expected with no warnings in AdvantageScope

## Screenshots (optional: if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The auto-formatter was working correctly when submitted
- [x] I have updated any comments accordingly.
