### PR TITLE
Changed LL Weightings, elevator heights, and coral expel speed

### DIFF
--- a/Comp2025/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/Comp2025/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -77,7 +77,8 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
 
     /* Robot pose for field positioning */
     private final NetworkTable          table                    = ntInst.getTable("Pose");
-    private final DoubleArrayPublisher  fieldPub                 = table.getDoubleArrayTopic("llPose").publish( );
+    private final DoubleArrayPublisher  fieldPubLeft             = table.getDoubleArrayTopic("llPose-left").publish( );
+    private final DoubleArrayPublisher  fieldPubRight            = table.getDoubleArrayTopic("llPose-right").publish( );
     private final StringPublisher       fieldTypePub             = table.getStringTopic(".type").publish( );
 
     // Network tables publisher objects
@@ -340,8 +341,8 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
             });
         }
         if (m_useLimelight && Robot.isReal( )) {
-            visionUpdate(Constants.kLLLeftName);
-            visionUpdate(Constants.kLLRightName);
+            visionUpdate(Constants.kLLLeftName, fieldPubLeft);
+            visionUpdate(Constants.kLLRightName, fieldPubRight);
         }
     }
 
@@ -436,7 +437,7 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
      * This example is sufficient to show that vision integration is possible, though exact
      * implementation of how to use vision should be tuned per-robot and to the team's specification.
      */
-    private void visionUpdate(String limelightName)
+    private void visionUpdate(String limelightName, DoubleArrayPublisher fieldPub)
     {
         boolean useMegaTag2 = DriverStation.isEnabled( ); //set to false to use MegaTag1
         boolean doRejectUpdate = false;
@@ -488,6 +489,7 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
             {
                 doRejectUpdate = true;
             }
+
             if (mt2 == null || mt2.tagCount == 0)
             {
                 doRejectUpdate = true;
@@ -497,6 +499,7 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
             {
                 doRejectUpdate = true;
             }
+
             if (!doRejectUpdate)
             {
                 fieldTypePub.set("Field2d");

--- a/Comp2025/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/Comp2025/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -469,6 +469,11 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
 
             if (!doRejectUpdate)
             {
+                fieldTypePub.set("Field2d");
+                fieldPub.set(new double[ ]
+                {
+                        mt1.pose.getX( ), mt1.pose.getY( ), mt1.pose.getRotation( ).getDegrees( )
+                });
                 setVisionMeasurementStdDevs(VecBuilder.fill(.5, .5, 9999999));
                 addVisionMeasurement(mt1.pose, mt1.timestampSeconds);
             }
@@ -476,8 +481,7 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
         }
         else if (useMegaTag2 == true)
         {
-            LimelightHelpers.SetRobotOrientation(limelightName, getState( ).Pose.getRotation( ).getDegrees( ), 0, 0, 0, 0,
-                    0);
+            LimelightHelpers.SetRobotOrientation(limelightName, getState( ).Pose.getRotation( ).getDegrees( ), 0, 0, 0, 0, 0);
             LimelightHelpers.PoseEstimate mt2 = LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2(limelightName);
 
             if (Math.abs(getPigeon2( ).getAngularVelocityZWorld( ).getValue( ).in(DegreesPerSecond)) > 720) // if our angular velocity is greater than 720 degrees per second, ignore vision updates
@@ -502,8 +506,8 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
                 });
                 // setVisionMeasurementStdDevs(VecBuilder.fill(.7, .7, 9999999)); // Sample code from limelight
                 // Code used by some teams to scale std devs by distance (below) and used by several teams
-                setVisionMeasurementStdDevs(VecBuilder.fill(Math.pow(0.5, mt2.tagCount) * 2 * mt2.avgTagDist,
-                        Math.pow(0.5, mt2.tagCount) * 2 * mt2.avgTagDist, Double.POSITIVE_INFINITY));
+                setVisionMeasurementStdDevs(VecBuilder.fill(Math.pow(0.5, mt2.tagCount) * 1.0 * mt2.avgTagDist,
+                        Math.pow(0.5, mt2.tagCount) * 1.0 * mt2.avgTagDist, Double.POSITIVE_INFINITY));
                 addVisionMeasurement(mt2.pose, mt2.timestampSeconds);
             }
         }

--- a/Comp2025/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/Comp2025/src/main/java/frc/robot/subsystems/Elevator.java
@@ -85,14 +85,14 @@ public class Elevator extends SubsystemBase
   private static final double  kHeightCoralStation     = 0.0;             // By definition - at coral station
 
   private static final double  kHeightCoralL1          = 3.0;             // By definition - at L1 for scoring coral
-  private static final double  kHeightCoralL2          = 8.25;             // By definition - at L2 for scoring coral
+  private static final double  kHeightCoralL2          = 8.0;             // By definition - at L2 for scoring coral
   private static final double  kHeightCoralL3          = 15.5;            // By definition - at L3 for scoring coral
-  private static final double  kHeightCoralL4          = 29.0;           // By definition - at L4 for scoring coral
+  private static final double  kHeightCoralL4          = 27.5;           // By definition - at L4 for scoring coral
 
   private static final double  kHeightAlgaeL23         = 11.0;            // By definition - at L23 for taking algae
-  private static final double  kHeightAlgaeL34         = 19.5;            // By definition - at L34 for taking algae
+  private static final double  kHeightAlgaeL34         = 20.5;            // By definition - at L34 for taking algae
   private static final double  kHeightAlgaeNet         = 30.75;           // By definition - at scoring algae in net
-  private static final double  kHeightAlgaeProcessor   = 4.0;             // By definition - at scoring algae in processor
+  private static final double  kHeightAlgaeProcessor   = 2.5;             // By definition - at scoring algae in processor
 
   /** Elevator manual move parameters */
   private enum JoystickMode

--- a/Comp2025/src/main/java/frc/robot/subsystems/Manipulator.java
+++ b/Comp2025/src/main/java/frc/robot/subsystems/Manipulator.java
@@ -74,7 +74,7 @@ public class Manipulator extends SubsystemBase
   private static final DutyCycleOut kClawRollerStop      = new DutyCycleOut(0.0).withIgnoreHardwareLimits(true);
 
   private static final DutyCycleOut kCoralSpeedAcquire   = new DutyCycleOut(-0.75).withIgnoreHardwareLimits(false);
-  private static final DutyCycleOut kCoralSpeedExpel     = new DutyCycleOut(-0.25).withIgnoreHardwareLimits(true);
+  private static final DutyCycleOut kCoralSpeedExpel     = new DutyCycleOut(-0.32).withIgnoreHardwareLimits(true);
 
   private static final DutyCycleOut kAlgaeSpeedAcquire   = new DutyCycleOut(0.5).withIgnoreHardwareLimits(true);
   private static final DutyCycleOut kAlgaeSpeedExpel     = new DutyCycleOut(-0.4).withIgnoreHardwareLimits(true);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description (What changed)
<!--- Describe your changes in detail -->
Added limelight pose tracking when in MegaTag1, tuned elevator heights from drive practice, increased coral ejection speed, and increased limelight std deviations relative to the tag distance.

## Motivation and Context (Why needed)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improvements from drive practice testing.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Compiles with no errors and no ***additional*** warnings
- [x] Simulates without crashes, errors or warnings
- [x] Simulates with the change under test successfully working
- [x] Tested in the robot with no crashes, errors or warnings
- [x] I verified the log messages were as expected with no warnings in AdvantageScope

## Screenshots (optional: if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The auto-formatter was working correctly when submitted
- [x] I have updated any comments accordingly.
