### PR TITLE
Update limelight megatag2 std deviations from testing

### DIFF
--- a/Comp2025/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/Comp2025/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -509,8 +509,8 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
                 });
                 // setVisionMeasurementStdDevs(VecBuilder.fill(.7, .7, 9999999)); // Sample code from limelight
                 // Code used by some teams to scale std devs by distance (below) and used by several teams
-                setVisionMeasurementStdDevs(VecBuilder.fill(Math.pow(0.5, mt2.tagCount) * 1.0 * mt2.avgTagDist,
-                        Math.pow(0.5, mt2.tagCount) * 1.0 * mt2.avgTagDist, Double.POSITIVE_INFINITY));
+                setVisionMeasurementStdDevs(VecBuilder.fill(Math.pow(0.5, mt2.tagCount) * 0.75 * mt2.avgTagDist,
+                        Math.pow(0.5, mt2.tagCount) * 0.75 * mt2.avgTagDist, Double.POSITIVE_INFINITY));
                 addVisionMeasurement(mt2.pose, mt2.timestampSeconds);
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description (What changed)
<!--- Describe your changes in detail -->
Increase weighting of Limelight poses when updating odometry

## Motivation and Context (Why needed)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Increased weighting is needed for more accurate autonomous modes

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Compiles with no errors and no ***additional*** warnings
- [x] Simulates without crashes, errors or warnings
- [x] Simulates with the change under test successfully working
- [x] Tested in the robot with no crashes, errors or warnings
- [x] I verified the log messages were as expected with no warnings in AdvantageScope

## Screenshots (optional: if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The auto-formatter was working correctly when submitted
- [x] I have updated any comments accordingly.
