### PR TITLE
Expel algae command

### DIFF
--- a/Comp2025/src/main/java/frc/robot/RobotContainer.java
+++ b/Comp2025/src/main/java/frc/robot/RobotContainer.java
@@ -413,6 +413,7 @@ public class RobotContainer
     // Xbox on MacOS { leftX = 0, leftY = 1, rightX = 2, rightY = 3, leftTrigger = 5, rightTrigger = 4}
     //
     m_operatorPad.leftTrigger(Constants.kTriggerThreshold).onTrue(new ScoreAlgae(m_elevator, m_manipulator, m_hid));
+    m_operatorPad.leftTrigger(Constants.kTriggerThreshold).onFalse(new ExpelAlgae(m_elevator, m_manipulator, m_hid));    
     m_operatorPad.rightTrigger(Constants.kTriggerThreshold).onTrue(new ScoreCoral(m_elevator, m_manipulator, m_hid));
 
     m_operatorPad.leftStick( ).toggleOnTrue(new LogCommand("operPad", "left stick"));

--- a/Comp2025/src/main/java/frc/robot/RobotContainer.java
+++ b/Comp2025/src/main/java/frc/robot/RobotContainer.java
@@ -52,6 +52,7 @@ import frc.robot.autos.AutoPreloadCoral2;
 import frc.robot.autos.AutoTest;
 import frc.robot.commands.AcquireAlgae;
 import frc.robot.commands.AcquireCoral;
+import frc.robot.commands.ExpelAlgae;
 import frc.robot.commands.ExpelCoral;
 import frc.robot.commands.LogCommand;
 import frc.robot.commands.ScoreAlgae;

--- a/Comp2025/src/main/java/frc/robot/commands/ExpelAlgae.java
+++ b/Comp2025/src/main/java/frc/robot/commands/ExpelAlgae.java
@@ -1,0 +1,85 @@
+package frc.robot.commands;
+
+import java.util.Map;
+import static edu.wpi.first.units.Units.Seconds;
+
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.wpilibj2.command.SelectCommand;
+import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
+import edu.wpi.first.wpilibj2.command.WaitCommand;
+import frc.robot.Constants;
+import frc.robot.Constants.CRConsts.ClawMode;
+import frc.robot.Constants.ELConsts;
+import frc.robot.Constants.ELConsts.ReefLevel;
+import frc.robot.subsystems.Elevator;
+import frc.robot.subsystems.HID;
+import frc.robot.subsystems.Manipulator;
+
+public class ExpelAlgae extends SequentialCommandGroup
+{
+    private ReefLevel selectLevel( )
+  {
+    NetworkTable table = NetworkTableInstance.getDefault( ).getTable(Constants.kRobotString);
+    int level = (int) table.getIntegerTopic(ELConsts.kReefLevelString).subscribe(0).get( );
+
+    switch (level)
+    {
+      default : // Algae Processor
+      case 1 :
+      case 2 :
+        return ReefLevel.ONE;
+      case 3 : // Algae Net
+      case 4 :
+        return ReefLevel.TWO;
+    }
+  }
+  /**
+   * Group command to use the subsystems to expel a coral onto the reef
+   * 
+   * @param elevator
+   *          elevator subsystem
+   * @param manipulator
+   *          manipulator subsystem
+   * @param hid
+   *          hid subsystem
+   */
+  public ExpelAlgae(Elevator elevator, Manipulator manipulator, HID hid)
+  {
+    setName("ExpelCoral");
+
+    addCommands(
+        // Add Commands here:
+
+        // @formatter:off
+
+        new LogCommand(getName(), "Start Claw Rollers"), 
+        new SelectCommand<>( 
+          // Maps selector values to commands 
+          Map.ofEntries( 
+                Map.entry(ReefLevel.ONE, manipulator.getMoveToPositionCommand(ClawMode.ALGAEEXPEL, manipulator::getCurrentAngle)), 
+                Map.entry(ReefLevel.TWO, manipulator.getMoveToPositionCommand(ClawMode.ALGAESHOOT, manipulator::getCurrentAngle))
+              ),  
+              this::selectLevel), 
+        
+        new LogCommand(getName(), "Wait for algae"),
+        new WaitCommand(Seconds.of(0.5)),
+        // new WaitUntilCommand(manipulator::isAlgaeDetected), // checks if algae is expelled 
+      
+        new LogCommand(getName(), "Stop algae rollers"),
+        manipulator.getMoveToPositionCommand(ClawMode.STOP, manipulator::getAngleSafeState), // Manipulator Safe State
+        
+        new LogCommand(getName(), "Move Elevator to stowed height"),
+        elevator.getMoveToPositionCommand(elevator::getHeightStowed)
+
+        // @formatter:on
+    );
+  }
+
+  @Override
+  public boolean runsWhenDisabled( )
+  {
+    return false;
+  }
+
+}

--- a/Comp2025/src/main/java/frc/robot/commands/ScoreAlgae.java
+++ b/Comp2025/src/main/java/frc/robot/commands/ScoreAlgae.java
@@ -1,7 +1,6 @@
 
 package frc.robot.commands;
 
-import static edu.wpi.first.units.Units.Seconds;
 
 import java.util.Map;
 
@@ -9,7 +8,6 @@ import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj2.command.SelectCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
-import edu.wpi.first.wpilibj2.command.WaitCommand;
 import frc.robot.Constants.CRConsts.ClawMode;
 import frc.robot.Constants;
 import frc.robot.Constants.ELConsts;
@@ -79,26 +77,7 @@ public class ScoreAlgae extends SequentialCommandGroup
                 Map.entry(ReefLevel.ONE, manipulator.getMoveToPositionCommand(ClawMode.ALGAEMAINTAIN, manipulator::getAngleAlgaeProcessor)), 
                 Map.entry(ReefLevel.TWO, manipulator.getMoveToPositionCommand(ClawMode.ALGAEMAINTAIN, manipulator::getAngleAlgaeNet))
               ),  
-              this::selectLevel), 
-
-        new LogCommand(getName(), "Start Claw Rollers"), 
-        new SelectCommand<>( 
-          // Maps selector values to commands 
-          Map.ofEntries( 
-                Map.entry(ReefLevel.ONE, manipulator.getMoveToPositionCommand(ClawMode.ALGAEEXPEL, manipulator::getCurrentAngle)), 
-                Map.entry(ReefLevel.TWO, manipulator.getMoveToPositionCommand(ClawMode.ALGAESHOOT, manipulator::getCurrentAngle))
-              ),  
-              this::selectLevel), 
-        
-        new LogCommand(getName(), "Wait for algae"),
-        new WaitCommand(Seconds.of(0.5)),
-        // new WaitUntilCommand(manipulator::isAlgaeDetected), // checks if algae is expelled 
-      
-        new LogCommand(getName(), "Stop algae rollers"),
-        manipulator.getMoveToPositionCommand(ClawMode.STOP, manipulator::getAngleSafeState), // Manipulator Safe State
-        
-        new LogCommand(getName(), "Move Elevator to stowed height"),
-        elevator.getMoveToPositionCommand(elevator::getHeightStowed)
+              this::selectLevel)
         
         // @formatter:on
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description (What changed)
<!--- Describe your changes in detail -->
Split ScoreAlgae command into a separate ExpelAlgae command that runs when button is released

## Motivation and Context (Why needed)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previous implementation caused the algae to move to the scoring position and expel without any operator control

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Compiles with no errors and no ***additional*** warnings
- [x] Simulates without crashes, errors or warnings
- [x] Simulates with the change under test successfully working
- [ ] Tested in the robot with no crashes, errors or warnings
- [x] I verified the log messages were as expected with no warnings in AdvantageScope

## Screenshots (optional: if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The auto-formatter was working correctly when submitted
- [x] I have updated any comments accordingly.
